### PR TITLE
Add garment receipt waste post loader and update usage

### DIFF
--- a/src/loader/garment-receipt-waste-post-loader.js
+++ b/src/loader/garment-receipt-waste-post-loader.js
@@ -1,0 +1,20 @@
+import { Container } from 'aurelia-dependency-injection';
+import { Config } from "aurelia-api";
+
+const resource = 'garment/waste/receipt/search';
+
+module.exports = function (keyword, filter, select) {
+
+    var config = Container.instance.get(Config);
+    var endpoint = config.getEndpoint("inventory-azure");
+
+    return endpoint.post(resource, { 
+        Keyword: keyword, 
+        Filter: JSON.stringify(filter), 
+        Select: select, 
+        Order: "{}"
+    })
+        .then(results => {
+            return results.data;
+        });
+}

--- a/src/modules/inventory/garment-waste/expenditure-waste/template/item.js
+++ b/src/modules/inventory/garment-waste/expenditure-waste/template/item.js
@@ -1,7 +1,7 @@
 import { inject, bindable, computedFrom } from 'aurelia-framework'
 import { Service } from "../service";
 
-var ReceiptWasteLoader = require('../../../../../loader/garment-receipt-waste-loader');
+var ReceiptWasteLoader = require('../../../../../loader/garment-receipt-waste-post-loader');
 
 @inject(Service)
 export class items {


### PR DESCRIPTION
Introduced a new loader 'garment-receipt-waste-post-loader' for searching garment waste receipts via POST requests. Updated the expenditure waste item template to use the new loader instead of the previous one.