### PR TITLE
Remove 'Bahan Embalase' from reprosesOption list -SPRINT 23

### DIFF
--- a/src/modules/garment-purchasing/monitoring-kedatangan-barang/list.js
+++ b/src/modules/garment-purchasing/monitoring-kedatangan-barang/list.js
@@ -9,8 +9,8 @@ var BuyerLoader = require('../../../loader/garment-buyers-loader');
 
 @inject(Router, BindingEngine, Service)
 export class List {
-  reprosesOption = ['','Bahan Baku', 'Bahan Pendukung', 'Bahan Embalase'];
-
+    //reprosesOption = ['','Bahan Baku', 'Bahan Pendukung', 'Bahan Embalase'];
+    reprosesOption = ['','Bahan Baku', 'Bahan Pendukung'];
   
     purchaseRequest = {};
     filter = {isPosted: true};


### PR DESCRIPTION
The 'Bahan Embalase' option has been removed from the reprosesOption array in the monitoring kedatangan barang list. This change likely reflects an update in the available options for the related process.