### PR TITLE
Minify bundle in build script - SPRINT 23

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "watch:dev:hmr": "npm run watch:dev -- --hot",
     "watch:test": "npm run test -- --auto-watch --no-single-run",
     "watch:prod": "npm run build:prod -- --watch",
-    "build": "npm run build:dev",
+    "build": "npm run build:dev && npx terser dist/app.bundle.js -o dist/app.bundle.min.js -c -m",
     "prebuild:dev": "npm run clean:dist",
     "build:dev": "cross-env NODE_ENV=development npm run webpack -- --progress --profile",
     "prebuild:prod": "npm run clean:dist",


### PR DESCRIPTION
Updated the build script in package.json to minify dist/app.bundle.js using Terser, producing dist/app.bundle.min.js after the development build.