### PR TITLE
Fix autocomplete data binding in scrap transaction form - SPRINT 24

### DIFF
--- a/src/modules/garment-production/scrap-transaction-in/data-form.js
+++ b/src/modules/garment-production/scrap-transaction-in/data-form.js
@@ -47,11 +47,27 @@ export class DataForm {
         this.error = this.context.error;
         this.options.isCreate = this.context.isCreate;
         this.options.isView = this.context.isView;
+          console.log(this.data);
         if(this.data)
         {
-            this.selectedSource= this.data.ScrapSourceName;
-            this.selectedDestination= this.data.ScrapDestinationName;
+            // Buat objek lengkap untuk autocomplete, bukan hanya string
+            if (this.data.ScrapSourceId && this.data.ScrapSourceName) {
+                this.selectedSource = {
+                    Id: this.data.ScrapSourceId,
+                    Name: this.data.ScrapSourceName,
+                    Code: this.data.ScrapSourceCode || '' // tambahkan Code jika ada
+                };
+            }
+            
+            if (this.data.ScrapDestinationId && this.data.ScrapDestinationName) {
+                this.selectedDestination = {
+                    Id: this.data.ScrapDestinationId,
+                    Name: this.data.ScrapDestinationName,
+                    Code: this.data.ScrapDestinationCode || '' // tambahkan Code jika ada
+                };
+            }
         }
+      
     }
     itemsInfo = {
         columns: [

--- a/src/modules/garment-production/scrap-transaction-in/edit.js
+++ b/src/modules/garment-production/scrap-transaction-in/edit.js
@@ -16,11 +16,13 @@ export class Edit {
         var id = params.id;
         var idDecoded = Base64Helper.decode(id);
         this.data = await this.service.read(idDecoded);
+
+        console.log(this.data);
     }
 
     bind(context) {
         this.context = context;
-        this.data = this.context.data;
+        // this.data = this.context.data; // Jangan timpa data yang sudah di-load dari activate()
         this.error = this.context.error;
         this.hasCancel=true;
         this.hasSave=true;


### PR DESCRIPTION
Updated the data-form to bind complete objects for selectedSource and selectedDestination instead of just strings, ensuring compatibility with autocomplete components. Also added console logs for debugging and prevented overwriting loaded data in the edit module.