### PR TITLE
Add new columns to profit by section report

### DIFF
--- a/src/modules/merchandiser/report/profit-garment-by-section-report/list.html
+++ b/src/modules/merchandiser/report/profit-garment-by-section-report/list.html
@@ -58,6 +58,13 @@
                     <th class="text-center">Profit/FOB %</th>
                     <th class="text-center">Gross Profit</th>    
                     <th class="text-center">Premi</th>
+                    <th class="text-center">Total</th>
+                    <th class="text-center">OTL 1</th>
+                    <th class="text-center">OTL 2</th>
+                    <th class="text-center">Resiko (%)</th>
+                    <th class="text-center">Biaya Angkut</th>
+                    <th class="text-center">Subtotal</th>
+
                 </tr>
             </thead>
             <tbody>
@@ -91,6 +98,12 @@
                         <td class="text-right">${item.ProfitFOB}</td>
                         <td class="text-right">${item.GrossProfit}</td>
                         <td class="text-right">${item.Premi}</td>
+                        <td class="text-right">${item.Total}</td>
+                        <td class="text-right">${item.OTL1}</td>
+                        <td class="text-right">${item.OTL2}</td>
+                        <td class="text-right">${item.PersenRisk}</td>
+                        <td class="text-right">${item.FreightCost}</td>
+                        <td class="text-right">${item.SubTotal}</td>
                     </tr>
                         <tr class="active">
                         <td class="text-center">.</td>

--- a/src/modules/merchandiser/report/profit-garment-by-section-report/list.js
+++ b/src/modules/merchandiser/report/profit-garment-by-section-report/list.js
@@ -92,6 +92,12 @@ export class List {
                             Amount : data.Amount.toLocaleString('en-EN',{minimumFractionDigits: 2, maximumFractionDigits: 2}),
                             GrossProfit : data.GrossProfit.toLocaleString('en-EN',{minimumFractionDigits: 2, maximumFractionDigits: 2}),
                             Premi : data.Premi.toLocaleString('en-EN',{minimumFractionDigits: 2, maximumFractionDigits: 2}),
+                            Total: data.Total.toLocaleString('en-EN',{minimumFractionDigits: 2, maximumFractionDigits: 2}),
+                            OTL1: data.OTL1.toLocaleString('en-EN',{minimumFractionDigits: 2, maximumFractionDigits: 2}),
+                            OTL2: data.OTL2.toLocaleString('en-EN',{minimumFractionDigits: 2, maximumFractionDigits: 2}),
+                            PersenRisk: data.PersenRisk.toLocaleString('en-EN',{minimumFractionDigits: 2, maximumFractionDigits: 2}),
+                            FreightCost: data.FreightCost.toLocaleString('en-EN',{minimumFractionDigits: 2, maximumFractionDigits: 2}),
+                            SubTotal: data.SubTotal.toLocaleString('en-EN',{minimumFractionDigits: 2, maximumFractionDigits: 2}),
                          });
                     
                         if (!subTotalSection[SECTION]) {


### PR DESCRIPTION
Added Total, OTL 1, OTL 2, Resiko (%), Biaya Angkut, and Subtotal columns to the profit garment by section report. Updated both the HTML template and JS data formatting to support these new fields.