### PR TITLE
Add garment-signature edit & Position

### DIFF
--- a/src/modules/garment-purchasing/master/garment-signature-master/data-form.html
+++ b/src/modules/garment-purchasing/master/garment-signature-master/data-form.html
@@ -3,14 +3,14 @@
     <au-input-form title.bind="title" with.bind="context">
         <div slot="actions" class="btn-group">
             <button class="btn btn-default" click.delegate="context.cancel($event)" if.one-way="context.hasCancel">Kembali</button>
-            <!-- <button class="btn btn-primary" click.delegate="context.edit($event)" if.one-way="context.hasEdit">Ubah</button> -->
+            <button class="btn btn-primary" click.delegate="context.edit($event)" if.one-way="context.hasEdit">Ubah</button>
             <button class="btn btn-success" click.delegate="context.save($event)" if.one-way="context.hasSave">Simpan</button>
             <button class="btn btn-danger" click.delegate="context.delete($event)" if.one-way="context.hasDelete">Hapus</button>
         </div>
         <au-autocomplete value.bind="selectedAccount" 
             error.bind="error.UserName" label="User Name" 
             loader.bind="accountLoader" text="username"
-            placeholder="cari user name" key="username" read-only.bind="readOnly" 
+            placeholder="cari user name" key="username" read-only.bind=" readOnly || isEdit" 
             options.bind="controlOptions" >
         </au-autocomplete>
         <au-textbox label="First Name" if.bind="selectedAccount"
@@ -25,8 +25,12 @@
             value.bind="selectedUnit" 
             error.bind="error.Unit" loader.bind="unitLoader"
             text.bind="unitView" placeholder="Unit" 
-            read-only.bind="readOnly" options.bind="controlOptions">
+            read-only.bind="readOnly || isEdit" options.bind="controlOptions">
         </au-autocomplete>
+        <au-textbox label="Jabatan"
+            value.bind="data.Position" error.bind="error.Position" 
+            read-only.bind="readOnly" options.bind="controlOptions">
+        </au-textbox>
         <!-- Upload Signature -->
         <div class="form-group row align-items-center">
             <label class="col-sm-4 col-form-label text-right">Signature</label>

--- a/src/modules/garment-purchasing/master/garment-signature-master/data-form.js
+++ b/src/modules/garment-purchasing/master/garment-signature-master/data-form.js
@@ -11,6 +11,7 @@ export class DataForm {
     @bindable title;
     @bindable selectedAccount;
     @bindable options = { readOnly: false };
+    //@bindable isEdit = false;
 
     get accountLoader() {
         return AccountLoader;

--- a/src/modules/garment-purchasing/master/garment-signature-master/edit.html
+++ b/src/modules/garment-purchasing/master/garment-signature-master/edit.html
@@ -1,0 +1,4 @@
+<template>
+  <require from="./data-form"></require>
+  <data-form title="Ubah Signature Garment"></data-form>
+</template>

--- a/src/modules/garment-purchasing/master/garment-signature-master/edit.js
+++ b/src/modules/garment-purchasing/master/garment-signature-master/edit.js
@@ -1,0 +1,35 @@
+import {inject, Lazy} from 'aurelia-framework';
+import {Router} from 'aurelia-router';
+import {Service} from './service';
+import { Base64Helper } from '../../../../utils/base-64-coded-helper';
+
+@inject(Router, Service)
+export class Edit {
+    constructor(router, service) {
+        this.router = router;
+        this.service = service;
+    }
+
+    async activate(params) {
+        const decoded = Base64Helper.decode(params.id);
+        var id = decoded;
+
+        this.data = await this.service.getById(id);
+    }
+
+    cancelCallback(event) {
+        const encoded = Base64Helper.encode(this.data.Id);
+        this.router.navigateToRoute('view', { id: encoded });
+    }
+
+    saveCallback(event) {
+        this.service.update(this.data)
+            .then(result => {
+                const encoded = Base64Helper.encode(this.data.Id);
+                this.router.navigateToRoute('view', { id: encoded });
+            })
+            .catch(e => {
+                this.error = e;
+            })
+    }
+}

--- a/src/modules/garment-purchasing/master/garment-signature-master/view.html
+++ b/src/modules/garment-purchasing/master/garment-signature-master/view.html
@@ -1,4 +1,4 @@
 <template>
     <require from="./data-form"></require>
-    <data-form title="Detail Signature Garment" read-only="true"></data-form>
+    <data-form title="Detail Signature Garment" read-only.bind="true"></data-form>
   </template>


### PR DESCRIPTION
Add an Edit screen and controller for garment signature master and tweak the data form to support editing. Changes include:

- Added edit.html and edit.js: new Edit view/controller that loads record by decoded id, saves updates and navigates to view (uses Base64Helper).
- Updated data-form.html: enabled the Edit button, made autocomplete and unit fields respect edit mode, added Position textbox, and fixed read-only binding in view.
- Minor change to data-form.js: left an isEdit bindable commented out.
- Updated view.html to bind read-only properly (read-only.bind="true").