### PR TITLE
Add garment purchasing debit/retur note modules

### DIFF
--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/dialog-template/reject-reason.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/dialog-template/reject-reason.html
@@ -1,0 +1,20 @@
+<template>
+  <ai-dialog>
+    <ai-dialog-header>
+      ${title}
+    </ai-dialog-header>
+
+    <ai-dialog-body>
+      <h4>${message}</h4>
+      <div class="form-group">
+        <textarea class="form-control" value.bind="reason" rows="4"></textarea>
+      </div>
+    </ai-dialog-body>
+
+    <ai-dialog-footer>
+      <button class="btn btn-default" click.trigger="controller.cancel()">Batal</button>
+      <button class="btn btn-danger" click.trigger="controller.ok(reason)">Reject</button>
+    </ai-dialog-footer>
+  </ai-dialog>
+</template>
+

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/dialog-template/reject-reason.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/dialog-template/reject-reason.js
@@ -1,0 +1,16 @@
+import { inject, useView } from 'aurelia-framework';
+import { DialogController } from 'aurelia-dialog';
+
+@inject(DialogController)
+@useView('./reject-reason.html')
+export class RejectReason {
+  constructor(controller) {
+    this.controller = controller;
+    this.reason = '';
+  }
+
+  activate(data) {
+    this.title = data.title || 'Alasan';
+    this.message = data.message || '';
+  }
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/index.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/index.html
@@ -1,0 +1,5 @@
+<template>
+    <div>
+        <router-view></router-view>
+    </div>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/index.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/index.js
@@ -1,0 +1,22 @@
+export class Index {
+  configureRouter(config, router) {
+    config.map([
+      {
+        route: ["", "list"],
+        moduleId: "./list",
+        name: "list",
+        nav: true,
+        title: "Daftar"
+      },
+      {
+        route: "view/:id",
+        moduleId: "./view",
+        name: "view",
+        nav: false,
+        title: "Detail"
+      }
+    ]);
+
+    this.router = router;
+  }
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/list.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/list.html
@@ -1,0 +1,11 @@
+<template>
+    <h1 class="page-header">${title}</h1>
+    <au-table
+        data.bind="loader"
+        columns.bind="columns"
+        sortable.bind="true"
+        page-size="25"
+        context.bind="context"
+        context-click.delegate="contextCallback($event)">
+    </au-table>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/list.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/list.js
@@ -1,0 +1,101 @@
+import { inject } from 'aurelia-framework';
+import { Service } from "./service";
+import { Router } from 'aurelia-router';
+import { activationStrategy } from 'aurelia-router';
+import { AuthService } from "aurelia-authentication";
+import { Base64Helper } from '../../../utils/base-64-coded-helper';
+import moment from 'moment';
+
+@inject(Router, Service, AuthService)
+export class List {
+    context = ["Detail"];
+    columns = [
+    
+            
+            { field: "DebetNoteNo", title: "Nomer Nota Debet" },
+            
+            {
+                field: "CreatedUtc", title: "Tanggal Nota Debet", formatter: function (value, data, index) {
+                    return moment(value).format("DD MMM YYYY");
+                }
+            },
+            { field: "SupplierName", title: "Nama Supplier" },
+            { field: "TotalAmount", title: "Total Amount" },
+            { field: "CreatedBy", title: "Dibuat Oleh" }
+    ];
+    filter = {};
+
+    loader = (info) => {
+        var order = {};
+
+        if (info.sort)
+            order[info.sort] = info.order;
+
+        var arg = {
+            page: parseInt(info.offset / info.limit, 10) + 1,
+            size: info.limit,
+            keyword: info.search,
+            order: order,
+            filter: JSON.stringify(this.filter)
+        }
+
+        return this.service.search(arg)
+            .then(result => {
+                result.data.map(data => {
+                    data.SupplierName = data.Supplier ? data.Supplier.Name : "";
+                    data.TotalAmount = data.TotalAmount;
+                    return data;
+                });
+                return {
+                    total: result.info.total,
+                    data: result.data
+                }
+            });
+        }
+
+    constructor(router, service, authService) {
+        this.service = service;
+        this.router = router;
+        this.authService = authService;
+    }
+
+    determineActivationStrategy() {
+        return activationStrategy.replace;
+    }
+
+    activate(params, routeConfig, navigationInstruction) {
+        const instruction = navigationInstruction.getAllInstructions()[0];
+        const parentInstruction = instruction.parentInstruction;
+        this.title = parentInstruction.config.title;
+        const type = parentInstruction.config.settings.type;
+        this.type = type;
+
+        let username = null;
+        if (this.authService.authenticated) {
+            const me = this.authService.getTokenPayload();
+            username = me.username;
+        }
+
+        switch (type) {
+            case "gm":
+                this.filter = {
+                    IsPosted: true,
+                    IsApprovedGeneralManager: false
+                };
+                break;
+            default:
+                break;
+        }
+    }
+
+    contextCallback(event) {
+        var arg = event.detail;
+        var data = arg.data;
+        const encoded = Base64Helper.encode(data.Id);
+        switch (arg.name) {
+            case "Detail":
+                this.router.navigateToRoute('view', { id: encoded });
+                break;
+        }
+    }
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/service.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/service.js
@@ -1,0 +1,35 @@
+import { RestService } from '../../../utils/rest-service';
+
+
+const serviceUri = 'garment-debet-note';
+
+class Service extends RestService {
+
+     constructor(http, aggregator, config, endpoint) {
+        super(http, aggregator, config, "purchasing-azure");
+    }
+
+     search(info) {
+        var endpoint = `${serviceUri}`;
+        return super.list(endpoint, info);
+    }
+
+    getById(id) {
+        var endpoint = `${serviceUri}/${id}`;
+        return super.get(endpoint);
+    }
+
+    replace(id, data) {
+        var endpoint = `${serviceUri}/${id}`;
+        return super.patch(endpoint, data);
+    }
+    
+    Rejected(id, reason) {
+    let endpoint = `${serviceUri}/debet-note-rejected/${id}`;
+    let body = { Reason: reason };
+    return super.put(endpoint, body);
+  }
+
+};
+
+export { Service }

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/template/debet-note-header.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/template/debet-note-header.html
@@ -1,0 +1,8 @@
+<template >
+    <tr>
+        <th repeat.for="column of columns">
+            <label>${column}</label>
+        </th>
+        <th if.bind="!readOnly" style="width: 75px;"><button type="button" click.delegate="addItem()" class="btn btn-success btn-sm">+</button></th>
+    </tr>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/template/debet-note-header.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/template/debet-note-header.js
@@ -1,0 +1,36 @@
+import { inject } from 'aurelia-framework';
+
+@inject(Element)
+export default class DebetNoteHeader {
+
+  constructor(element) {
+    this.element = element;
+  }
+
+  activate(context) {
+    this.context = context;
+    this.data = context.data;
+    this.items = context.items;
+    
+    // Handle options from parent context
+    if (context.context && context.context.options) {
+        this.options = context.context.options;
+    } else if (context.options) {
+        this.options = context.options;
+    } else {
+        this.options = {};
+    }
+    
+    this.readOnly = this.options.readOnly !== undefined ? this.options.readOnly : true;
+  }
+
+  addItem() {
+    if (
+      this.context &&
+      this.context.options &&
+      typeof this.context.options.add === 'function'
+    ) {
+      this.context.options.add();
+    }
+  }
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/template/item-footer.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/template/item-footer.html
@@ -1,0 +1,15 @@
+<template>
+  <tr>
+    <td colspan="4" class="text-right" style="padding-right:10%">
+      Total
+    </td>
+    <td>
+      <au-textbox value.one-way="currency" error.bind="error.currency" read-only.bind="true"></au-textbox>
+    </td>
+    <td colspan.bind="readOnly ? 1 : 2" class="text-left">
+      <require from="../../../../lib/number-format-value-converter"></require>
+      ${itemSum | numberFormat:"0,000.00"}
+    </td>
+    
+  </tr>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/template/item-footer.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/template/item-footer.js
@@ -1,0 +1,36 @@
+import { inject, bindable, computedFrom } from 'aurelia-framework';
+import { Container } from 'aurelia-dependency-injection';
+import { Config } from "aurelia-api"
+
+export class DetailFooter {
+  activate(context) {
+    this.context = context;
+    
+    // Handle options from parent context
+    if (context.context && context.context.options) {
+        this.options = context.context.options;
+    } else if (context.options) {
+        this.options = context.options;
+    } else {
+        this.options = {};
+    }
+    
+    this.readOnly = this.options.readOnly !== undefined ? this.options.readOnly : true;
+  }
+
+  get currency(){
+    if (this.options && this.options.CurrencyCode) {
+        return this.options.CurrencyCode;
+    }
+    return this.context.options ? this.context.options.CurrencyCode : '';
+  }
+
+  get itemSum() {
+    var qty = this.context.items
+      .map((item) => item.data.AmountFinal || 0);
+    return qty
+      .reduce((prev, curr, index) => { return prev + curr }, 0);
+  }
+
+
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/template/item.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/template/item.html
@@ -1,0 +1,107 @@
+<template>
+  <tr>
+    <!-- <require from="../../../../lib/number-format-value-converter"></require> -->
+    <td if.bind="options.isEdit">
+      <au-datepicker value.bind="data.DebetNoteDate"
+                     error.bind="error.DebetNoteDate"
+                     read-only.bind="true"
+                     options.bind="controlOptions">
+      </au-datepicker>
+    </td>
+    <td>
+      <au-multiline value.bind="data.Description"
+                  error.bind="error.Description"
+                  placeholder="Keterangan"
+                  read-only.bind="readOnly"
+                  options.bind="controlOptions">
+      </au-multiline>
+    </td>
+    <td>
+      <au-numeric value.bind="selectedAmount"
+                  read-only.bind="readOnly"
+                  error.bind="error.Amount"
+                  format="0,0.00"
+                  options.bind="controlOptions">
+      </au-numeric>
+    </td>
+    <td style="text-align:center;">
+      <au-checkbox value.bind="selectedVat"
+                   error.bind="error.IsGetPpn"
+                   read-only.bind="readOnly"
+                   options.bind="controlOptions"
+                   checked.bind="IsGetPpn">
+      </au-checkbox>
+
+      <br>
+
+      <div show.bind="selectedVat">
+        <au-autocomplete value.bind="selectedVatTax"
+                         error.bind="error.VatTax"
+                         loader.bind="vatTaxLoader"
+                         placeholder="cari ppn"
+                         text.bind="vatTaxView"
+                         read-only.bind="readOnly">
+        </au-autocomplete>
+        
+      </div>
+
+    </td>
+    <td style="text-align:center;">
+      <au-checkbox value.bind="selectedPPh"
+                   error.bind="error.IsGetPph"
+                   read-only.bind="readOnly"
+                   options.bind="controlOptions"
+                   checked.bind="IsGetPph">
+      </au-checkbox>
+      <br>
+
+      <div show.bind="selectedPPh">
+        <au-autocomplete value.bind="selectedIncomeTax"
+                         error.bind="error.IncomeTax"
+                         loader.bind="incomeTaxLoader"
+                         placeholder="cari pph"
+                         text.bind="incomeTaxView"
+                         read-only.bind="readOnly">
+        </au-autocomplete>
+
+        <br>
+
+
+        <numeric label="Rate" value.bind="data.IncomeTax.Rate" error.bind="error.incomeTaxRate" format="0"
+          read-only.bind="true" post-fix="%" options.bind="controlOptions">
+
+        </numeric>
+
+        <au-textbox value.bind="'Ditanggung Oleh:'"
+                    read-only.bind="true">
+        </au-textbox>
+
+        <br>
+
+        <au-dropdown items.bind="IncomeTaxByOptions"
+                     value.bind="selectedIncomeTaxBy"
+                     error.bind="error.IncomeTaxBy"
+                     read-only.bind="readOnly"
+                     options.bind="controlOptions">
+        </au-dropdown>
+
+      </div>
+
+    </td>
+    <td>
+      <!-- <au-numeric value.bind="Total" read-only.bind="true" format="0,0.000" options.bind="controlOptions">
+            </au-numeric> -->
+      <au-numeric value.bind="data.AmountFinal"
+                  read-only.bind="true"
+                  format="0,0.00"
+                  options.bind="controlOptions">
+      </au-numeric>
+      <!-- <au-textbox value.bind="vbRequestTotalCalc" read-only.bind="true" show.bind="false" format="0,0.000"
+                options.bind="controlOptions">
+            </au-textbox> -->
+    </td>
+    <td if.bind="!readOnly" class="text-center">
+      <button type="button" class="btn btn-danger btn-sm" click.delegate="onremove(data, $event)">-</button>
+    </td>
+  </tr>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/template/item.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/template/item.js
@@ -1,0 +1,183 @@
+import { bindable, computedFrom, BindingSignaler, inject } from 'aurelia-framework';
+var IncomeTaxLoader = require('../../../../loader/income-tax-loader');
+var VatTaxLoader = require('../../../../loader/vat-tax-loader');
+
+// @inject(BindingSignaler)
+export class Item {
+
+  controlOptions = {
+    label: {
+      align: "right",
+      length: 5,
+    },
+    control: {
+      length: 5,
+      align: "right",
+    },
+  };
+
+  constructor() {
+  }
+
+  activate(context) {
+    this.data = context.data;
+    this.error = context.error;
+    
+    // Handle options from parent context
+    if (context.context && context.context.options) {
+        this.options = context.context.options;
+    } else if (context.options) {
+        this.options = context.options;
+    } else {
+        this.options = {};
+    }
+    
+    this.readOnly = this.options.readOnly !== undefined ? this.options.readOnly : true;
+
+    // this.selectedIncomeTax = this.data.IncomeTax || null;
+    this.selectedIncomeTaxBy = this.data.IncomeTaxBy || "";
+    this.selectedAmount = this.data.Amount || 0;
+    this.selectedPPh = this.data.IsGetPph;
+    this.selectedVat = this.data.IsGetPpn;
+
+
+    if (this.data.IncomeTax) {
+      this.selectedIncomeTax = this.data.IncomeTax;
+      this.selectedIncomeTax.name = this.data.IncomeTax.Name;
+      this.selectedIncomeTax.rate = this.data.IncomeTax.Rate ? this.data.IncomeTax.Rate : 0;
+      this.data.IncomeTax.rate = this.data.IncomeTax.Rate ? this.data.IncomeTax.Rate : 0;
+    }
+
+    if (this.data.VatTax) {
+      this.selectedVatTax = this.data.VatTax;
+      this.selectedVatTax.Rate = this.data.VatTax.Rate ? this.data.VatTax.Rate :"";
+      this.data.VatTax.Rate = this.data.VatTax.Rate ? this.data.VatTax.Rate : "";
+    }
+   
+
+    this.calculateTotalAmount();
+  }
+
+  IncomeTaxByOptions = ["", "Supplier", "Dan Liris"];
+
+  get incomeTaxLoader() {
+    return IncomeTaxLoader;
+  }
+
+  incomeTaxView = (incomeTax) => {
+
+    return incomeTax.name ? `${incomeTax.name} - ${incomeTax.rate}` : "";
+
+  }
+
+  vatTaxView = (vatTax) => {
+    return vatTax.rate ? `${vatTax.rate}` : `${vatTax.Rate}`;
+  }
+
+  get vatTaxLoader() {
+    return VatTaxLoader;
+}
+
+  @bindable selectedIncomeTaxBy;
+  selectedIncomeTaxByChanged(newValue) {
+    if (newValue) {
+      this.data.IncomeTaxBy = newValue
+      this.calculateTotalAmount();
+    }
+    else {
+      delete this.data.IncomeTaxBy;
+      this.calculateTotalAmount();
+    }
+  }
+
+  @bindable selectedVat;
+  selectedVatChanged(newValue) {
+    if (newValue) {
+      this.data.IsGetPpn = newValue
+      this.calculateTotalAmount();
+    } else {
+      this.selectedVatTax = null;
+      delete this.data.IsGetPpn;
+      this.calculateTotalAmount();
+    }
+  }
+
+  @bindable selectedPPh;
+  selectedPPhChanged(newValue) {
+    if (newValue) {
+      this.data.IsGetPph = newValue;
+      this.calculateTotalAmount();
+    } else {
+      this.selectedIncomeTax = null;
+      this.selectedIncomeTaxBy = "";
+      delete this.data.IsGetPph;
+      this.calculateTotalAmount();
+    }
+  }
+
+
+  calculateTotalAmount() {
+    let incomeTaxRate = this.data.IncomeTax ? this.data.IncomeTax.rate : 0;
+    if (this.data.IncomeTaxBy == "Supplier" && this.data.IsGetPph && this.data.IncomeTax) {
+      let vatAmount = 0;
+      if (this.data.IsGetPpn && this.data.VatTax)
+        vatAmount = this.data.VatTax.Rate == 12 ? this.data.Amount *11/12 * (this.data.VatTax.Rate / 100): this.data.Amount * (this.data.VatTax.Rate / 100);
+      let pphAmount = this.data.Amount * (incomeTaxRate / 100);
+      this.data.AmountPPH = pphAmount;
+      this.data.AmountPPN = vatAmount;
+      this.data.AmountFinal = Math.round((this.data.Amount - pphAmount + vatAmount + Number.EPSILON) * 100) / 100;
+    } else {
+      let vatAmount = 0;
+      if (this.data.IsGetPpn && this.data.VatTax)
+        //vatAmount = this.data.Amount * (this.data.VatTax.Rate / 100);
+        vatAmount = this.data.VatTax.Rate == 12 ? this.data.Amount *11/12 * (this.data.VatTax.Rate / 100): this.data.Amount * (this.data.VatTax.Rate / 100);
+      let pphAmount = this.data.Amount * (incomeTaxRate / 100);
+      this.data.AmountPPH = pphAmount;
+      this.data.AmountPPN = vatAmount;
+      this.data.AmountFinal = Math.round((this.data.Amount + vatAmount + Number.EPSILON) * 100) / 100;
+      
+    }
+    if (this.options.updateTotalAmount) {
+      this.options.updateTotalAmount();
+    }
+  }
+
+
+
+  @bindable selectedIncomeTax;
+  selectedIncomeTaxChanged(newValue, oldValue) {
+    if (newValue) {
+      this.data.IncomeTax = newValue;
+      this.data.IncomeTax.Rate = this.data.IncomeTax.rate;
+      this.data.IncomeTax.Name = this.data.IncomeTax.name;
+      this.calculateTotalAmount();
+
+    } else {
+      this.data.IncomeTax = {};
+      this.data.IncomeTax.Rate = 0;
+      this.data.IncomeTax.Name = "";
+      this.calculateTotalAmount();
+    }
+  }
+
+  @bindable selectedVatTax;
+  selectedVatTaxChanged(newValue, oldValue) {
+    if (newValue) {
+      this.data.VatTax = newValue;
+      this.data.VatTax.Rate = this.data.VatTax.Rate;
+      this.calculateTotalAmount();
+    }else{
+      this.data.VatTax = {};
+      this.data.VatTax.Rate = "";
+      this.calculateTotalAmount();
+  }
+}
+
+  @bindable selectedAmount;
+  selectedAmountChanged(newValue, oldValue) {
+    if (newValue) {
+      this.data.Amount = newValue;
+      this.calculateTotalAmount();
+    }
+  }
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/view.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/view.html
@@ -1,0 +1,71 @@
+<template>
+  <require from="../../../lib/number-format-value-converter.js"></require>
+  <require from="../../../lib/date-format-value-converter.js"></require>
+
+  <au-input-form 
+      title.bind="title" 
+      with.bind="context" 
+      options.bind="formOptions" 
+      edit.call="editCallback($event)" 
+      delete.call="deleteCallback($event)">
+    
+    <div class="row">
+      <div class="col-md-6">
+        <au-textbox 
+            label=""
+            read-only.bind="true"
+            options.bind="controlOptions">
+        </au-textbox>
+        
+        <au-textbox 
+            label="Nomor Nota Debet" 
+            value.bind="data.DebetNoteNo" 
+            read-only.bind="true"
+            options.bind="controlOptions">
+        </au-textbox>
+
+        <au-textbox 
+            label="Supplier" 
+            value.bind="data.Supplier.Name" 
+            read-only.bind="true"
+            options.bind="controlOptions">
+        </au-textbox>
+
+        <au-textbox 
+            label="Alamat Supplier" 
+            value.bind="data.Supplier.Address" 
+            read-only.bind="true"
+            if.bind="data.Supplier"
+            options.bind="controlOptions">
+        </au-textbox>
+        
+        <au-textbox 
+            label="Mata Uang"
+            value.bind="data.Currency.Code"
+            read-only.bind="true"
+            options.bind="controlOptions">
+        </au-textbox>
+        
+        <au-multiline
+            label="Keterangan"
+            value.bind="data.Remarks"
+            read-only.bind="true" 
+            options.bind="controlOptions">
+        </au-multiline>
+      </div>
+    </div>
+
+    <br>
+    <h4>Daftar Item</h4>
+    <au-collection 
+        items.bind="data.Items" 
+        columns.bind="itemsInfo.columns"
+        options.bind="itemsInfo.options"
+        read-only.bind="readOnly"
+        header-template="modules/garment-purchasing/purchasing-debet-note-approval/template/debet-note-header"
+        item-template="modules/garment-purchasing/purchasing-debet-note-approval/template/item"
+        footer-template="modules/garment-purchasing/purchasing-debet-note-approval/template/item-footer">
+    </au-collection>
+    
+  </au-input-form>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note-approval/view.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note-approval/view.js
@@ -1,0 +1,165 @@
+import { inject } from "aurelia-framework";
+import { Router } from "aurelia-router";
+import { Service } from "./service";
+import { Dialog } from "../../../au-components/dialog/dialog";
+import { AuthService } from "aurelia-authentication";
+import { RejectReason } from "./dialog-template/reject-reason";
+import moment from 'moment';
+import numeral from 'numeral';
+import { Base64Helper } from '../../../utils/base-64-coded-helper';
+
+numeral.defaultFormat("0,0.00");
+
+@inject(Router, Service, Dialog, AuthService)
+export class View {
+    readOnly = true;
+    
+    controlOptions = {
+        label: {
+            align: "right",
+            length: 5,
+        },
+        control: {
+            length: 5,
+            align: "right",
+        },
+    };
+    
+    length4 = {
+        label: {
+            align: "left",
+            length: 4
+        }
+    };
+    length6 = {
+        label: {
+            align: "left",
+            length: 6
+        }
+    };
+    length7 = {
+        label: {
+            align: "left",
+            length: 7
+        }
+    };
+
+    formOptions = {
+        cancelText: "Kembali",
+        editText: "Approve",
+        deleteText: "Reject"
+    };
+
+    itemsInfo = {
+        columns: ["Tanggal", "Keterangan", "Jumlah", "Kena PPN", "PPh", "Total"],
+        options: {}
+    }
+
+    constructor(router, service, dialog, authService) {
+        this.router = router;
+        this.service = service;
+        this.dialog = dialog;
+        this.authService = authService;
+    }
+
+    async activate(params, routeConfig, navigationInstruction) {
+        const instruction = navigationInstruction.getAllInstructions()[0];
+        const parentInstruction = instruction.parentInstruction;
+        this.title = parentInstruction.config.title;
+        const type = parentInstruction.config.settings.type;
+
+        switch (type) {
+            case "gm":
+                this.type = "GeneralManager";
+                break;
+            default: break;
+        }
+
+        if (this.authService.authenticated) {
+            this.me = this.authService.getTokenPayload();
+        }
+        else {
+            this.me = null;
+        }
+
+        var id = params.id;
+        let decoded = Base64Helper.decode(id);
+        id = decoded;
+        this.data = await this.service.getById(id);
+        this.error = {};
+
+        // Setup options for templates
+        if (!this.itemsInfo.options) {
+            this.itemsInfo.options = {};
+        }
+        this.itemsInfo.options.readOnly = this.readOnly;
+        this.itemsInfo.options.isEdit = true;
+        
+        if (this.data.Currency) {
+            this.itemsInfo.options.CurrencyCode = this.data.Currency.Code;
+        }
+
+    
+    
+        if (this.data.DispositionDate) {
+            this.data.DispositionDateFormatted = moment(this.data.DispositionDate).format("DD MMMM YYYY");
+        }
+
+        this.editCallback = this.approve;
+        this.deleteCallback = this.reject;
+    }
+
+    async bind(context) {
+        this.context = context;
+    }
+
+    list() {
+        this.router.navigateToRoute("list");
+    }
+
+    cancelCallback(event) {
+        this.list();
+    }
+
+    approve(event) {
+        if (confirm("Approve Disposition?")) {
+            const jsonPatch = [
+                { op: "replace", path: `/IsApproved${this.type}`, value: true },
+                { op: "replace", path: `/Approved${this.type}By`, value: this.me.username },
+                { op: "replace", path: `/Approved${this.type}Date`, value: new Date() }
+            ];
+
+            this.service.replace(this.data.Id, jsonPatch)
+                .then(result => {
+                    this.list();
+                })
+                .catch(e => {
+                    this.error = e;
+                    if (e.statusCode === 500) {
+                        alert("Gagal menyimpan, silakan coba lagi!");
+                    }
+                });
+        }
+    }
+
+    reject(event) {
+       this.dialog.show(RejectReason, {message: "Silakan masukkan alasan reject:" })
+        .then(response => {
+        if (!response.wasCancelled) {
+            const reason = response.output;
+            if (!reason || String(reason).trim() === "") {
+            alert('Alasan tidak boleh kosong.');
+            return;
+            }
+            this.service
+            .Rejected(this.data.Id, String(reason).trim())
+            .then((result) => {
+                this.list();
+            })
+            .catch((e) => {
+                this.error = e;
+            });
+        }
+        });
+    }
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note/create.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note/create.html
@@ -1,0 +1,4 @@
+<template>
+    <require from="./data-form"></require>
+    <data-form title="Nota Debet"></data-form>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note/create.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note/create.js
@@ -1,0 +1,46 @@
+import {inject, Lazy} from 'aurelia-framework';
+import {Router} from 'aurelia-router';
+import {Service} from './service';
+import {activationStrategy} from 'aurelia-router';
+
+@inject(Router, Service)
+export class Create {
+    hasCancel = true;
+    hasSave = true;
+
+    constructor(router, service) {
+        this.router = router;
+        this.service = service;
+        this.data = {};
+    }
+    activate(params) {
+
+    }
+    bind() {
+        this.data = { Items: [] };
+        this.error = {};
+    }
+
+    cancel(event) {
+        this.router.navigateToRoute('list');
+    }
+
+    determineActivationStrategy() {
+        return activationStrategy.replace;
+    }
+
+    save(event) {
+        this.service.create(this.data)
+            .then(result => {
+                alert("Data berhasil dibuat");
+                this.router.navigateToRoute('create',{}, { replace: true, trigger: true });
+            })
+            .catch(e => {
+                if (e.statusCode === 500) {
+                    alert("Gagal menyimpan, silakan coba lagi!");
+                } else {
+                    this.error = e;
+                }
+            })
+    }
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note/data-form.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note/data-form.html
@@ -1,0 +1,85 @@
+<template>
+    <au-input-form 
+        title.bind="title" 
+        with.bind="context">
+
+        <div class="row">
+            <div class="col-md-6">
+                <au-textbox 
+                    label=""
+                    read-only.bind="true"
+                    options.bind="controlOptions">
+                </au-textbox>
+                
+                <au-textbox 
+                    label="Nomor Nota Debet" 
+                    value.bind="data.DebetNoteNo" 
+                    error.bind="error.DebetNoteNo" 
+                    read-only.bind="true"
+                    if.bind="(readOnly || isEdit)"
+                    options.bind="controlOptions">
+                </au-textbox>
+
+                <au-autocomplete 
+                    label="Supplier" 
+                    value.bind="selectedSupplier" 
+                    error.bind="error.Supplier" 
+                    loader.bind="supplierLoader" 
+                    query.bind="supplierQuery" 
+                    text.bind="supplierView" 
+                    placeholder="cari supplier" 
+                    key="code"
+                    read-only.bind="readOnly" 
+                    options.bind="controlOptions">
+                </au-autocomplete>
+
+                <au-textbox 
+                    label="Alamat Supplier" 
+                    value.bind="data.Supplier.Address" 
+                    error.bind="error.SupplierAddress" 
+                    read-only.bind="readOnly"
+                    if.bind="data.Supplier"
+                    options.bind="controlOptions">
+                </au-textbox>
+                
+                 <au-autocomplete label="Mata Uang"
+                       value.bind="currency"
+                       error.bind="error.Currency"
+                       loader.one-time="currencyLoader"
+                       text="Code"
+                       read-only.bind="readOnly"
+                       options.bind="controlOptions">
+                 </au-autocomplete>
+                 <au-multiline
+                    label="Keterangan"
+                    value.bind="data.Remarks"
+                    error.bind="error.Remarks"
+                    read-only.bind="readOnly" 
+                    options.bind="controlOptions">
+                </au-multiline>
+            </div>
+    </div>
+
+        <au-textbox error.bind="error.Itemscount" read-only.bind="true"></au-textbox>
+
+        <au-collection 
+            items.bind="data.Items" 
+            errors.bind="error.Items"
+            columns.bind="items.columns"
+            options.bind="options"
+            read-only.bind="readOnly" 
+            if.bind="isItem"
+            header-template="modules/garment-purchasing/purchasing-debet-note/template/debet-note-header"
+            item-template="modules/garment-purchasing/purchasing-debet-note/template/item"
+            footer-template="modules/garment-purchasing/purchasing-debet-note/template/item-footer">
+        </au-collection>
+    
+        <div slot="actions" class="btn-group">
+            <button type="button" class="btn btn-default" click.delegate="context.cancel($event)"     if.one-way="context.hasCancel">Kembali</button>
+            <button type="button" class="btn btn-primary" click.delegate="context.edit($event)"    if.bind="context.hasEdit">Ubah</button>
+            <button type="button" class="btn btn-success" click.delegate="context.save($event)"       if.one-way="context.hasSave">Simpan</button>
+            <button type="button" class="btn btn-danger"  click.delegate="context.delete($event)"   if.bind="context.hasDelete">Hapus</button>
+            <button class="btn btn-primary" click.delegate="context.unpost($event)" if.one-way="context.hasUnpost && !data.IsApprovedGeneralManager">Unpost</button>
+        </div>
+  </au-input-form>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note/data-form.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note/data-form.js
@@ -1,0 +1,167 @@
+import {
+  inject,
+  bindable,
+  containerless,
+  computedFrom,
+  BindingEngine,
+  TaskQueue,
+} from "aurelia-framework";
+import { Service } from "./service";
+import { AuthService } from "aurelia-authentication";
+var SupplierLoader = require('../../../loader/garment-supplier-loader');
+var CurrencyLoader = require('../../../loader/currency-loader');
+import moment from "moment";
+
+@inject(Service, BindingEngine, AuthService, TaskQueue)
+export class DataForm {
+  @bindable readOnly = false;
+  @bindable data = {};
+  @bindable error = {};
+  @bindable title;
+  @bindable options = {};
+  @bindable selectedSupplier;
+
+
+  controlOptions = {
+    label: {
+      align: "right",
+      length: 5,
+    },
+    control: {
+      length: 5,
+      align: "right",
+    },
+  };
+
+  constructor(service, bindingEngine, authService, taskQueue) {
+    this.service = service;
+    this.bindingEngine = bindingEngine;
+    this.authService = authService;
+    this.taskQueue = taskQueue;
+    this._itemSubscriptions = new Map();
+  }
+
+  bind(context) {
+    this.context = context;
+    this.data = this.context.data;
+    this.error = this.context.error;
+    this.isItem = false;
+    this.isEdit = this.data.Id ? true : false;
+
+    if (!this.data.Items) {
+      this.data.Items = [];
+    }
+    
+    this.options.readOnly = this.readOnly;
+    this.options.isEdit = this.isEdit;
+    this.options.add = () => {
+      this.addItems();
+    };
+
+    this.options.updateTotalAmount = () => {
+      this.data.TotalAmount = this.itemSum;
+    };
+
+    if (this.data.Currency) {
+            this.currency = this.data.Currency;
+        }
+
+    if (this.data.Supplier) {
+        this.selectedSupplier = this.data.Supplier;
+    }
+
+    this.readOnlySender = true;
+
+    if (!this.isEdit) {
+      this.addItems();
+    }
+
+    this.isItem = this.data.Items && this.data.Items.length > 0;
+
+    this.itemSumSubscription = this.bindingEngine.propertyObserver(this, 'itemSum').subscribe(() => {
+      this.data.TotalAmount = this.itemSum;
+    });
+    this.data.TotalAmount = this.itemSum;
+  
+  }
+
+  addItems() {
+    if (!this.data.Items) {
+      this.data.Items = [];
+    }
+    var item = { 
+      AmountFinal: 0,
+      Amount: 0,
+      IsNew: true
+    };
+    this.data.Items.push(item);
+  }
+
+
+
+  get items() {
+    let cols = ["Keterangan", "Jumlah", "Kena PPN", "PPh", "Total"];
+    if (this.isEdit) {
+      cols.unshift("Tanggal");
+    }
+    return { 
+      columns: cols
+    };
+  }
+
+  @computedFrom('data.Items')
+  get itemSum() {
+    if (this.data.Items && this.data.Items.length > 0) {
+      return this.data.Items.reduce((sum, item) => sum + (item.AmountFinal || 0), 0);
+    }
+    return 0;
+  }
+
+  @bindable currency;
+    currencyChanged(n, o) {
+        if (this.currency) {
+            this.data.Currency = this.currency;
+            this.options.CurrencyCode = this.data.Currency.Code;
+
+        } else {
+            this.data.Currency = null;
+        }
+    }
+
+
+  async selectedSupplierChanged(newValue) {
+        var _selectedSupplier = newValue;
+        if (_selectedSupplier && (_selectedSupplier.Id || _selectedSupplier.id)) {
+            if (!this.data.Supplier) {
+                this.data.Supplier = {};
+            }
+            this.data.Supplier.Code = _selectedSupplier.code || _selectedSupplier.Code;
+            this.data.Supplier.Name = _selectedSupplier.name || _selectedSupplier.Name;
+            this.data.Supplier.Id = _selectedSupplier.Id || _selectedSupplier.id;
+            this.data.Supplier.Address = _selectedSupplier.address || _selectedSupplier.Address;
+        } else {
+            this.data.Supplier = null;
+        }
+    }
+
+  get supplierLoader() {
+        return SupplierLoader;
+    }
+
+   supplierView = (supplier) => {
+        var code = supplier.code ? supplier.code : supplier.Code;
+        var name = supplier.name ? supplier.name : supplier.Name;
+        return `${code} - ${name}`
+    }
+
+   get currencyLoader() {
+          return CurrencyLoader;
+      }
+
+  unbind() {
+    if (this.itemSumSubscription) {
+      this.itemSumSubscription.dispose();
+    }
+  }
+
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note/edit.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note/edit.html
@@ -1,0 +1,6 @@
+<template>
+  <require from="./data-form"></require>
+  <data-form 
+      title="Nota Debet">
+  </data-form>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note/edit.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note/edit.js
@@ -1,0 +1,50 @@
+import { inject, Lazy } from 'aurelia-framework';
+import { Router } from 'aurelia-router';
+import { Service } from './service';
+import { Base64Helper } from '../../../utils/base-64-coded-helper';
+
+
+@inject(Router, Service)
+export class Edit {
+    hasCancel = true;
+    hasSave = true;
+
+    constructor(router, service) {
+        this.router = router;
+        this.service = service;
+    }
+
+    bind() {
+        this.error = {};
+    }
+
+    async activate(params) {
+        var id = params.id;
+        let decoded = Base64Helper.decode(id);
+        id = decoded;
+        this.data = await this.service.getById(id);
+        
+
+        if (this.data.Items) {
+            for (let item of this.data.Items) {
+                item.IsSave = true;
+                item.IsDisabled = false;
+            }
+        }
+
+    }
+
+    cancel(event) {
+        const encoded = Base64Helper.encode(this.data.Id);
+        this.router.navigateToRoute('view', { id: encoded });
+    }
+
+    save(event) {
+        this.service.update(this.data).then(result => {
+            this.cancel();
+        }).catch(e => {
+            this.error = e;
+        })
+    }
+}
+

--- a/src/modules/garment-purchasing/purchasing-debet-note/index.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note/index.html
@@ -1,0 +1,5 @@
+<template> 
+  <div> 
+    <router-view></router-view>
+  </div>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note/index.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note/index.js
@@ -1,0 +1,12 @@
+export class Index {
+    configureRouter(config, router) {
+        config.map([
+            { route: ['', 'list'], moduleId: './list', name: 'list', nav: false, title: 'List: Nota Debet' },
+            { route: 'create', moduleId: './create', name: 'create', nav: false, title: 'Create: Nota Debet' },
+            { route: 'view/:id', moduleId: './view', name: 'view', nav: false, title: 'View: Nota Debet' },
+            { route: 'edit/:id', moduleId: './edit', name: 'edit', nav: false, title: 'Edit: Nota Debet' },
+        ]);
+
+        this.router = router;
+    }
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note/list.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note/list.html
@@ -1,0 +1,21 @@
+<template>
+    <h1 class="page-header">Nota Debet </h1>
+    <au-table 
+        view-model.ref="table" 
+        data.bind="loader" 
+        columns.bind="columns" 
+        sortable.bind="true" 
+        page-size="25" 
+        context.bind="context"
+        context-click.delegate="contextClickCallback($event)" 
+        context-show.call="contextShowCallback(index, context, data)"
+        selectable.bind="true" 
+        selections.bind="dataToBePosted" 
+        row-formatter.bind="rowFormatter">
+            
+        <div slot="toolbar" class="btn-group">
+            <button class="btn btn-success" click.delegate="create()">Buat</button>
+             <button class="btn btn-primary" disabled.bind="!dataToBePosted.length > 0" click.delegate="posting()">Posting</button>
+        </div>
+    </au-table>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note/list.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note/list.js
@@ -1,0 +1,114 @@
+import { inject } from 'aurelia-framework';
+import { Service } from "./service";
+import { Router } from 'aurelia-router';
+import moment from 'moment';
+import { Base64Helper } from '../../../utils/base-64-coded-helper';
+
+@inject(Router, Service)
+export class List {
+    dataToBePosted = [];
+
+    context = ["Rincian", "Cetak PDF"]
+
+    columns = [
+
+        {
+            field: "isPosting", title: "Post", checkbox: true, sortable: false,
+            formatter: function (value, data, index) {
+                this.checkboxEnabled = !data.IsPosted;
+                return ""
+            }
+         },
+        
+        { field: "DebetNoteNo", title: "Nomer Nota Debet" },
+        {
+            field: "CreatedUtc", title: "Tanggal Nota Debet", formatter: function (value, data, index) {
+                return moment(value).format("DD MMM YYYY");
+            }
+        },
+        { field: "SupplierName", title: "Nama Supplier" },
+        { field: "TotalAmount", title: "Total Amount" },
+        { field: "IsPostedLabel", title: "Status Posting" },
+        { field: "IsApprovedGMLabel", title: "Approval GM Purchasing" },
+        { field: "ReasonRejected", title: "Alasan Reject" }
+    ];
+
+    rowFormatter(data, index) {
+        if (data.ReasonRejected) {
+            return { classes: "" };
+        } else if (data.IsApprovedGeneralManager) {
+            return { classes: "success" };
+        } else {
+            return { classes: "danger" };
+        }
+    }
+
+    loader = (info) => {
+        var order = {};
+        if (info.sort)
+            order[info.sort] = info.order;
+        var arg = {
+            page: parseInt(info.offset / info.limit, 10) + 1,
+            size: info.limit,
+            keyword: info.search,
+            order: order,
+        }
+
+        return this.service.search(arg)
+            .then(result => {
+                result.data.map(data => {
+                    data.IsPostedLabel  = data.IsPosted ? "SUDAH" : "BELUM";
+                    data.SupplierName = data.Supplier ? data.Supplier.Name : "";
+                    data.IsApprovedGMLabel = data.IsApprovedGeneralManager ? "SUDAH" : "BELUM";
+                    return data;
+                });
+                return {
+                    total: result.info.total,
+                    data: result.data
+                }
+            });
+    }
+
+    constructor(router, service) {
+        this.service = service;
+        this.router = router;
+    }
+
+   
+    contextClickCallback(event) {
+        var arg = event.detail;
+        var data = arg.data;
+        const encoded = Base64Helper.encode(data.Id);
+        switch (arg.name) {
+            case "Rincian":
+                this.router.navigateToRoute('view', { id: encoded });
+                break;
+            case "Cetak PDF":
+                this.service.getPdfById(data.Id);
+                break;
+        }
+    }
+
+    contextShowCallback(index, name, data) {
+        switch (name) {
+            case "Cetak PDF":
+                return data.Id;
+            default:
+                return true;
+        }
+    }
+
+    create() {
+        this.router.navigateToRoute('create');
+    }
+
+    posting() {
+        if (this.dataToBePosted.length > 0) {
+        this.service.post(this.dataToBePosted).then(result => {
+            this.table.refresh();
+        }).catch(e => {
+            this.error = e;
+        })
+        }
+    }
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note/service.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note/service.js
@@ -1,0 +1,62 @@
+import { inject, Lazy } from 'aurelia-framework';
+import { HttpClient } from 'aurelia-fetch-client';
+import { RestService } from '../../../utils/rest-service';
+import { Container } from 'aurelia-dependency-injection';
+import { Config } from "aurelia-api";
+import moment from 'moment';
+
+const serviceUri = 'garment-debet-note';
+
+
+
+export class Service extends RestService {
+
+    constructor(http, aggregator, config, endpoint) {
+        super(http, aggregator, config, "purchasing-azure");
+    }
+
+    search(info) {
+        var endpoint = `${serviceUri}/by-user`;
+        return super.list(endpoint, info);
+    }
+
+    getById(id) {
+        var endpoint = `${serviceUri}/${id}`;
+        return super.get(endpoint);
+    }
+
+    create(data) {
+        var endpoint = `${serviceUri}`;
+        return super.post(endpoint, data);
+    }
+
+    update(data) {
+        var endpoint = `${serviceUri}/${data.Id}`;
+        return super.put(endpoint, data);
+    }
+
+    delete(data) {
+        var endpoint = `${serviceUri}/${data.Id}`;
+        return super.delete(endpoint, data);
+    }
+
+    getPdfById(id) {
+        var endpoint = `${serviceUri}/${id}`;
+        return super.getPdf(endpoint);
+    }
+
+    post(data) {
+        var endpoint = `${serviceUri}/post`;
+        return super.post(endpoint, data);
+    }
+
+    unpost(id) {
+        var endpoint = `${serviceUri}/unpost/${id}`;
+        return super.put(endpoint);
+    }
+
+ 
+}
+
+
+

--- a/src/modules/garment-purchasing/purchasing-debet-note/template/debet-note-header.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note/template/debet-note-header.html
@@ -1,0 +1,8 @@
+<template >
+    <tr>
+        <th repeat.for="column of columns">
+            <label>${column}</label>
+        </th>
+        <th if.bind="!readOnly" style="width: 75px;"><button type="button" click.delegate="addItem()" class="btn btn-success btn-sm">+</button></th>
+    </tr>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note/template/debet-note-header.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note/template/debet-note-header.js
@@ -1,0 +1,27 @@
+import { inject } from 'aurelia-framework';
+
+@inject(Element)
+export default class DebetNoteHeader {
+
+  constructor(element) {
+    this.element = element;
+  }
+
+  activate(context) {
+    this.context = context;
+    this.data = context.data;
+    this.items = context.items;
+    this.options = context.options;
+    this.readOnly = this.options.readOnly;
+  }
+
+  addItem() {
+    if (
+      this.context &&
+      this.context.options &&
+      typeof this.context.options.add === 'function'
+    ) {
+      this.context.options.add();
+    }
+  }
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note/template/item-footer.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note/template/item-footer.html
@@ -1,0 +1,15 @@
+<template>
+  <tr>
+    <td colspan="4" class="text-right" style="padding-right:10%">
+      Total
+    </td>
+    <td>
+      <au-textbox value.one-way="currency" error.bind="error.currency" read-only.bind="true"></au-textbox>
+    </td>
+    <td colspan.bind="readOnly ? 1 : 2" class="text-left">
+      <require from="../../../../lib/number-format-value-converter"></require>
+      ${itemSum | numberFormat:"0,000.00"}
+    </td>
+    
+  </tr>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note/template/item-footer.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note/template/item-footer.js
@@ -1,0 +1,23 @@
+import { inject, bindable, computedFrom } from 'aurelia-framework';
+import { Container } from 'aurelia-dependency-injection';
+import { Config } from "aurelia-api"
+
+export class DetailFooter {
+  activate(context) {
+    this.context = context;
+  }
+
+  get currency(){
+    return this.context.options.CurrencyCode;
+
+  }
+
+  get itemSum() {
+    var qty = this.context.items
+      .map((item) => item.data.AmountFinal || 0);
+    return qty
+      .reduce((prev, curr, index) => { return prev + curr }, 0);
+  }
+
+
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note/template/item.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note/template/item.html
@@ -1,0 +1,106 @@
+<template>
+  <tr>
+    <!-- <require from="../../../../lib/number-format-value-converter"></require> -->
+    <td if.bind="options.isEdit">
+      <au-datepicker value.bind="data.DebetNoteDate"
+                     error.bind="error.DebetNoteDate"
+                     read-only.bind="true"
+                     options.bind="controlOptions">
+      </au-datepicker>
+    </td>
+    <td>
+      <au-multiline value.bind="data.Description"
+                  error.bind="error.Description"
+                  placeholder="Keterangan"
+                  read-only.bind="readOnly"
+                  options.bind="controlOptions">
+      </au-multiline>
+    </td>
+    <td>
+      <au-numeric value.bind="selectedAmount"
+                  read-only.bind="readOnly"
+                  error.bind="error.Amount"
+                  format="0,0.00"
+                  options.bind="controlOptions">
+      </au-numeric>
+    </td>
+    <td style="text-align:center;">
+      <au-checkbox value.bind="selectedVat"
+                   error.bind="error.IsGetPpn"
+                   read-only.bind="readOnly"
+                   options.bind="controlOptions"
+                   checked.bind="IsGetPpn">
+      </au-checkbox>
+
+      <br>
+
+      <div show.bind="selectedVat">
+        <au-autocomplete value.bind="selectedVatTax"
+                         error.bind="error.VatTax"
+                         loader.bind="vatTaxLoader"
+                         placeholder="cari ppn"
+                         text.bind="vatTaxView"
+                         read-only.bind="readOnly">
+        </au-autocomplete>
+        
+      </div>
+
+    </td>
+    <td style="text-align:center;">
+      <au-checkbox value.bind="selectedPPh"
+                   error.bind="error.IsGetPph"
+                   read-only.bind="readOnly"
+                   options.bind="controlOptions"
+                   checked.bind="IsGetPph">
+      </au-checkbox>
+      <br>
+
+      <div show.bind="selectedPPh">
+        <au-autocomplete value.bind="selectedIncomeTax"
+                         error.bind="error.IncomeTax"
+                         loader.bind="incomeTaxLoader"
+                         placeholder="cari pph"
+                         text.bind="incomeTaxView"
+                         read-only.bind="readOnly">
+        </au-autocomplete>
+
+        <br>
+
+
+        <numeric label="Rate" value.bind="data.IncomeTax.Rate" error.bind="error.incomeTaxRate" format="0"
+          read-only.bind="true" post-fix="%" options.bind="controlOptions">
+
+        </numeric>
+
+        <au-textbox value.bind="'Ditanggung Oleh:'"
+                    read-only.bind="true">
+        </au-textbox>
+
+        <br>
+
+        <au-dropdown items.bind="IncomeTaxByOptions"
+                     value.bind="selectedIncomeTaxBy"
+                     error.bind="error.IncomeTaxBy"
+                     read-only.bind="readOnly"
+                     options.bind="controlOptions">
+        </au-dropdown>
+
+      </div>
+
+    </td>
+    <td>
+      <au-numeric value.bind="data.AmountFinal"
+                  read-only.bind="true"
+                  format="0,0.00"
+                  error.bind="error.AmountFinal"
+                  options.bind="controlOptions">
+      </au-numeric>
+    </td>
+    <td class="col-sm-1"
+        if.bind="!readOnly">
+      <button class="btn btn-danger pull-right"
+              click.delegate="onremove(data, $event)">-
+      </button>
+    </td>
+  </tr>
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note/template/item.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note/template/item.js
@@ -1,0 +1,166 @@
+import { bindable, computedFrom, BindingSignaler, inject } from 'aurelia-framework';
+var IncomeTaxLoader = require('../../../../loader/income-tax-loader');
+var VatTaxLoader = require('../../../../loader/vat-tax-loader');
+
+// @inject(BindingSignaler)
+export class Item {
+
+  constructor() {
+  }
+
+  activate(context) {
+    this.data = context.data;
+    this.error = context.error;
+    this.options = context.context.options;
+    this.readOnly = context.options.readOnly;
+
+    this.selectedIncomeTaxBy = this.data.IncomeTaxBy || "";
+    this.selectedAmount = this.data.Amount || 0;
+    this.selectedPPh = this.data.IsGetPph;
+    this.selectedVat = this.data.IsGetPpn;
+
+
+    if (this.data.IncomeTax) {
+      this.selectedIncomeTax = this.data.IncomeTax;
+      this.selectedIncomeTax.name = this.data.IncomeTax.Name;
+      this.selectedIncomeTax.rate = this.data.IncomeTax.Rate ? this.data.IncomeTax.Rate : 0;
+      this.data.IncomeTax.rate = this.data.IncomeTax.Rate ? this.data.IncomeTax.Rate : 0;
+    }
+
+    if (this.data.VatTax) {
+      this.selectedVatTax = this.data.VatTax;
+      this.selectedVatTax.Rate = this.data.VatTax.Rate ? this.data.VatTax.Rate :"";
+      this.data.VatTax.Rate = this.data.VatTax.Rate ? this.data.VatTax.Rate : "";
+    }
+   
+
+    this.calculateTotalAmount();
+  }
+
+  IncomeTaxByOptions = ["", "Supplier", "Dan Liris"];
+
+  get incomeTaxLoader() {
+    return IncomeTaxLoader;
+  }
+
+  incomeTaxView = (incomeTax) => {
+
+    return incomeTax.name ? `${incomeTax.name} - ${incomeTax.rate}` : "";
+
+  }
+
+  vatTaxView = (vatTax) => {
+    return vatTax.rate ? `${vatTax.rate}` : `${vatTax.Rate}`;
+  }
+
+  get vatTaxLoader() {
+    return VatTaxLoader;
+}
+
+  @bindable selectedIncomeTaxBy;
+  selectedIncomeTaxByChanged(newValue) {
+    if (newValue) {
+      this.data.IncomeTaxBy = newValue
+      this.calculateTotalAmount();
+    }
+    else {
+      delete this.data.IncomeTaxBy;
+      this.calculateTotalAmount();
+    }
+  }
+
+  @bindable selectedVat;
+  selectedVatChanged(newValue) {
+    if (newValue) {
+      this.data.IsGetPpn = newValue
+      this.calculateTotalAmount();
+    } else {
+      this.selectedVatTax = null;
+      delete this.data.IsGetPpn;
+      this.calculateTotalAmount();
+    }
+  }
+
+  @bindable selectedPPh;
+  selectedPPhChanged(newValue) {
+    if (newValue) {
+      this.data.IsGetPph = newValue;
+      this.calculateTotalAmount();
+    } else {
+      this.selectedIncomeTax = null;
+      this.selectedIncomeTaxBy = "";
+      delete this.data.IsGetPph;
+      this.calculateTotalAmount();
+    }
+  }
+
+
+  calculateTotalAmount() {
+    let incomeTaxRate = this.data.IncomeTax ? this.data.IncomeTax.rate : 0;
+    if (this.data.IncomeTaxBy == "Supplier" && this.data.IsGetPph && this.data.IncomeTax) {
+      let vatAmount = 0;
+      if (this.data.IsGetPpn && this.data.VatTax)
+        vatAmount = this.data.VatTax.Rate == 12 ? this.data.Amount *11/12 * (this.data.VatTax.Rate / 100): this.data.Amount * (this.data.VatTax.Rate / 100);
+      let pphAmount = this.data.Amount * (incomeTaxRate / 100);
+      this.data.AmountPPH = pphAmount;
+      this.data.AmountPPN = vatAmount;
+      this.data.AmountFinal = Math.round((this.data.Amount - pphAmount + vatAmount + Number.EPSILON) * 100) / 100;
+    } else {
+      let vatAmount = 0;
+      if (this.data.IsGetPpn && this.data.VatTax)
+        //vatAmount = this.data.Amount * (this.data.VatTax.Rate / 100);
+        vatAmount = this.data.VatTax.Rate == 12 ? this.data.Amount *11/12 * (this.data.VatTax.Rate / 100): this.data.Amount * (this.data.VatTax.Rate / 100);
+      let pphAmount = this.data.Amount * (incomeTaxRate / 100);
+      this.data.AmountPPH = pphAmount;
+      this.data.AmountPPN = vatAmount;
+      this.data.AmountFinal = Math.round((this.data.Amount + vatAmount + Number.EPSILON) * 100) / 100;
+      
+    }
+    if (this.options.updateTotalAmount) {
+      this.options.updateTotalAmount();
+    }
+  }
+
+
+
+  @bindable selectedIncomeTax;
+  selectedIncomeTaxChanged(newValue, oldValue) {
+    if (newValue) {
+      this.data.IncomeTax = newValue;
+      this.data.IncomeTax.Rate = this.data.IncomeTax.rate;
+      this.data.IncomeTax.Name = this.data.IncomeTax.name;
+      this.calculateTotalAmount();
+
+    } else {
+      this.data.IncomeTax = {};
+      this.data.IncomeTax.Rate = 0;
+      this.data.IncomeTax.Name = "";
+      this.calculateTotalAmount();
+    }
+  }
+
+  @bindable selectedVatTax;
+  selectedVatTaxChanged(newValue, oldValue) {
+    if (newValue) {
+      this.data.VatTax = newValue;
+      this.data.VatTax.Rate = this.data.VatTax.Rate;
+      this.calculateTotalAmount();
+    }else{
+      this.data.VatTax = {};
+      this.data.VatTax.Rate = "";
+      this.calculateTotalAmount();
+  }
+}
+
+  @bindable selectedAmount;
+  selectedAmountChanged(newValue) {
+  this.data.Amount = (newValue === 0) ? 0 : (newValue || 0);
+  this.calculateTotalAmount();
+}
+  // selectedAmountChanged(newValue, oldValue) {
+  //   if (newValue) {
+  //     this.data.Amount = newValue;
+  //     this.calculateTotalAmount();
+  //   }
+  // }
+}

--- a/src/modules/garment-purchasing/purchasing-debet-note/view.html
+++ b/src/modules/garment-purchasing/purchasing-debet-note/view.html
@@ -1,0 +1,7 @@
+<template>
+  <require from="./data-form"></require>
+  <data-form 
+      title="Nota Debet" 
+      read-only="true">
+  </data-form> 
+</template>

--- a/src/modules/garment-purchasing/purchasing-debet-note/view.js
+++ b/src/modules/garment-purchasing/purchasing-debet-note/view.js
@@ -1,0 +1,82 @@
+import { inject, Lazy } from "aurelia-framework";
+import { Router } from "aurelia-router";
+import { Service } from "./service";
+import { Base64Helper } from '../../../utils/base-64-coded-helper';
+
+@inject(Router, Service)
+export class View {
+  hasCancel = true;
+  hasEdit = true;
+  hasDelete = true;
+  hasUnpost = false;
+  dispoId = "";
+
+  constructor(router, service) {
+    this.router = router;
+    this.service = service;
+  }
+  async activate(params) {
+    var id = params.id;
+    let decoded = Base64Helper.decode(id);
+    this.dispoId = decoded;
+    id = decoded;
+    this.data = await this.service.getById(id);
+    
+    if (!this.data.IsPosted) {
+            this.hasEdit = true;
+            this.hasDelete = true;
+        } else {
+            if (!this.data.IsUsed) {
+                this.hasUnpost = true;
+            }
+        }
+
+    if (this.hasUnpost) {
+        this.hasEdit = false;
+        this.hasDelete = false;
+    }
+
+    if (this.data.Items) {
+      for (let item of this.data.Items) {
+        item.IsSave = true;
+      }
+    }
+  
+
+    if (this.data.IsReceived) {
+      this.hasEdit = false;
+      this.hasDelete = false;
+    }
+  }
+
+  cancel(event) {
+    var r = confirm("Apakah anda yakin akan keluar?");
+    if (r == true) {
+      this.router.navigateToRoute("list");
+    }
+  }
+
+  edit(event) {
+    const encoded = Base64Helper.encode(this.data.Id);
+    var r = confirm("Apakah anda yakin akan mengubah data ini?");
+    if (r == true) {
+      this.router.navigateToRoute("edit", { id: encoded });
+    }
+  }
+
+  delete(event) {
+    var r = confirm("Apakah anda yakin akan menghapus data ini?");
+    if (r == true) {
+      this.service.delete(this.data).then((result) => {
+        this.cancel();
+      });
+    }
+  }
+  unpost(event) {
+        this.service.unpost(this.dispoId).then(result => {
+            this.cancel();
+        }).catch(e => {
+            this.error = e;
+        })
+    }
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/dialog-template/reject-reason.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/dialog-template/reject-reason.html
@@ -1,0 +1,20 @@
+<template>
+  <ai-dialog>
+    <ai-dialog-header>
+      ${title}
+    </ai-dialog-header>
+
+    <ai-dialog-body>
+      <h4>${message}</h4>
+      <div class="form-group">
+        <textarea class="form-control" value.bind="reason" rows="4"></textarea>
+      </div>
+    </ai-dialog-body>
+
+    <ai-dialog-footer>
+      <button class="btn btn-default" click.trigger="controller.cancel()">Batal</button>
+      <button class="btn btn-danger" click.trigger="controller.ok(reason)">Reject</button>
+    </ai-dialog-footer>
+  </ai-dialog>
+</template>
+

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/dialog-template/reject-reason.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/dialog-template/reject-reason.js
@@ -1,0 +1,16 @@
+import { inject, useView } from 'aurelia-framework';
+import { DialogController } from 'aurelia-dialog';
+
+@inject(DialogController)
+@useView('./reject-reason.html')
+export class RejectReason {
+  constructor(controller) {
+    this.controller = controller;
+    this.reason = '';
+  }
+
+  activate(data) {
+    this.title = data.title || 'Alasan';
+    this.message = data.message || '';
+  }
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/index.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/index.html
@@ -1,0 +1,5 @@
+<template>
+    <div>
+        <router-view></router-view>
+    </div>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/index.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/index.js
@@ -1,0 +1,22 @@
+export class Index {
+  configureRouter(config, router) {
+    config.map([
+      {
+        route: ["", "list"],
+        moduleId: "./list",
+        name: "list",
+        nav: true,
+        title: "Daftar"
+      },
+      {
+        route: "view/:id",
+        moduleId: "./view",
+        name: "view",
+        nav: false,
+        title: "Detail"
+      }
+    ]);
+
+    this.router = router;
+  }
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/list.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/list.html
@@ -1,0 +1,11 @@
+<template>
+    <h1 class="page-header">${title}</h1>
+    <au-table
+        data.bind="loader"
+        columns.bind="columns"
+        sortable.bind="true"
+        page-size="25"
+        context.bind="context"
+        context-click.delegate="contextCallback($event)">
+    </au-table>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/list.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/list.js
@@ -1,0 +1,100 @@
+import { inject } from 'aurelia-framework';
+import { Service } from "./service";
+import { Router } from 'aurelia-router';
+import { activationStrategy } from 'aurelia-router';
+import { AuthService } from "aurelia-authentication";
+import { Base64Helper } from '../../../utils/base-64-coded-helper';
+import moment from 'moment';
+
+@inject(Router, Service, AuthService)
+export class List {
+    context = ["Detail"];
+    columns = [
+    
+            { field: "ReturNoteNo", title: "Nomer Nota Retur" },
+            
+            {
+                field: "ReturNoteDate", title: "Tanggal Nota Retur", formatter: function (value, data, index) {
+                    return moment(value).format("DD MMM YYYY");
+                }
+            },
+            { field: "SupplierName", title: "Nama Supplier" },
+            { field: "BKPReturnPrice", title: "Jumlah Harga Jual BKP" },
+            { field: "CreatedBy", title: "Dibuat Oleh" }
+    ];
+    filter = {};
+
+    loader = (info) => {
+        var order = {};
+
+        if (info.sort)
+            order[info.sort] = info.order;
+
+        var arg = {
+            page: parseInt(info.offset / info.limit, 10) + 1,
+            size: info.limit,
+            keyword: info.search,
+            order: order,
+            filter: JSON.stringify(this.filter)
+        }
+
+        return this.service.search(arg)
+            .then(result => {
+                result.data.map(data => {
+                    data.SupplierName = data.Supplier ? data.Supplier.Name : "";
+                    data.TotalAmount = data.TotalAmount;
+                    return data;
+                });
+                return {
+                    total: result.info.total,
+                    data: result.data
+                }
+            });
+        }
+
+    constructor(router, service, authService) {
+        this.service = service;
+        this.router = router;
+        this.authService = authService;
+    }
+
+    determineActivationStrategy() {
+        return activationStrategy.replace;
+    }
+
+    activate(params, routeConfig, navigationInstruction) {
+        const instruction = navigationInstruction.getAllInstructions()[0];
+        const parentInstruction = instruction.parentInstruction;
+        this.title = parentInstruction.config.title;
+        const type = parentInstruction.config.settings.type;
+        this.type = type;
+
+        let username = null;
+        if (this.authService.authenticated) {
+            const me = this.authService.getTokenPayload();
+            username = me.username;
+        }
+
+        switch (type) {
+            case "gm":
+                this.filter = {
+                    IsPosted: true,
+                    IsApprovedGeneralManager: false
+                };
+                break;
+            default:
+                break;
+        }
+    }
+
+    contextCallback(event) {
+        var arg = event.detail;
+        var data = arg.data;
+        const encoded = Base64Helper.encode(data.Id);
+        switch (arg.name) {
+            case "Detail":
+                this.router.navigateToRoute('view', { id: encoded });
+                break;
+        }
+    }
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/service.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/service.js
@@ -1,0 +1,35 @@
+import { RestService } from '../../../utils/rest-service';
+
+
+const serviceUri = 'garment-retur-note';
+
+class Service extends RestService {
+
+     constructor(http, aggregator, config, endpoint) {
+        super(http, aggregator, config, "purchasing-azure");
+    }
+
+     search(info) {
+        var endpoint = `${serviceUri}`;
+        return super.list(endpoint, info);
+    }
+
+    getById(id) {
+        var endpoint = `${serviceUri}/${id}`;
+        return super.get(endpoint);
+    }
+
+    replace(id, data) {
+        var endpoint = `${serviceUri}/${id}`;
+        return super.patch(endpoint, data);
+    }
+    
+    Rejected(id, reason) {
+    let endpoint = `${serviceUri}/retur-note-rejected/${id}`;
+    let body = { Reason: reason };
+    return super.put(endpoint, body);
+  }
+
+};
+
+export { Service }

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/template/item-footer.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/template/item-footer.html
@@ -1,0 +1,42 @@
+
+<template>
+  <tr>
+    <td colspan="3" class="text-right" style="padding-right:10%">
+      Jumlah Harga Jual BKP yang dikembalikan
+    </td>
+    <td>
+      <au-textbox value.one-way="currency" error.bind="error.currency" read-only.bind="true"></au-textbox>
+    </td>
+    <td colspan.bind="readOnly ? 1 : 2" class="text-left">
+      <require from="../../../../lib/number-format-value-converter"></require>
+      ${bkpReturnPrice | numberFormat:"0,000.00"}
+    </td>
+    
+  </tr>
+  <tr>
+    <td colspan="3" class="text-right" style="padding-right:10%">
+      Dasar Pengenaan Pajak Nilai Lain
+    </td>
+    <td>
+      <au-textbox value="IDR" read-only.bind="true"></au-textbox>
+    </td>
+    <td colspan.bind="readOnly ? 1 : 2" class="text-left">
+      <require from="../../../../lib/number-format-value-converter"></require>
+      ${otherTaxBaseAmount | numberFormat:"0,000.00"}
+    </td>
+    
+  </tr>
+  <tr>
+    <td colspan="3" class="text-right" style="padding-right:10%">
+      PPN yang diminta kembali
+    </td>
+    <td>
+      <au-textbox value="IDR" read-only.bind="true"></au-textbox>
+    </td>
+    <td colspan.bind="readOnly ? 1 : 2" class="text-left">
+      <require from="../../../../lib/number-format-value-converter"></require>
+      ${vatToBeRefunded | numberFormat:"0,000.00"}
+    </td>
+    
+  </tr>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/template/item-footer.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/template/item-footer.js
@@ -1,0 +1,25 @@
+import { inject, bindable, computedFrom } from 'aurelia-framework';
+import { Container } from 'aurelia-dependency-injection';
+import { Config } from "aurelia-api"
+
+export class DetailFooter {
+  activate(context) {
+    this.context = context;
+  }
+
+  get currency(){
+    return this.context.options.CurrencyCode || '';
+  }
+
+  get bkpReturnPrice() {
+    return this.context.options.BKPReturnPrice || 0;
+  }
+
+  get otherTaxBaseAmount() {
+    return this.context.options.OtherTaxBaseAmount || 0;
+  }
+
+  get vatToBeRefunded() {
+    return this.context.options.VatToBeRefunded || 0;
+  }
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/template/item-header.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/template/item-header.html
@@ -1,0 +1,8 @@
+<template >
+    <tr>
+        <th repeat.for="column of columns">
+            <label>${column}</label>
+        </th>
+        <th if.bind="!readOnly" style="width: 75px;"><button type="button" click.delegate="addItem()" class="btn btn-success btn-sm">+</button></th>
+    </tr>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/template/item-header.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/template/item-header.js
@@ -1,0 +1,27 @@
+import { inject } from 'aurelia-framework';
+
+@inject(Element)
+export default class DebetNoteHeader {
+
+  constructor(element) {
+    this.element = element;
+  }
+
+  activate(context) {
+    this.context = context;
+    this.data = context.data;
+    this.items = context.items;
+    this.options = context.options;
+    this.readOnly = this.options.readOnly;
+  }
+
+  addItem() {
+    if (
+      this.context &&
+      this.context.options &&
+      typeof this.context.options.add === 'function'
+    ) {
+      this.context.options.add();
+    }
+  }
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/template/item.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/template/item.html
@@ -1,0 +1,54 @@
+<template>
+  <tr>
+    <td>
+      <au-multiline value.bind="data.Description"
+                  error.bind="error.Description"
+                  placeholder="Keterangan"
+                  read-only.bind="readOnly"
+                  options.bind="controlOptions">
+      </au-multiline>
+    </td>
+    <td>
+      <au-numeric 
+          value.bind="selectedQuantity"
+          read-only.bind="readOnly"
+          error.bind="error.Quantity"
+          options.bind="controlOptions">
+      </au-numeric>
+    </td>
+    <td>
+            <au-autocomplete 
+                value.bind="dataUom" 
+                error.bind="error.Uom"
+                loader.bind="uomLoader"
+                placeholder="cari satuan" 
+                text="Unit"
+                key="Id"
+                read-only.bind="readOnly"
+                options.bind="controlOptions">
+            </au-autocomplete>
+        </td>
+    <td>
+      <au-numeric value.bind="selectedPricePerUnit"
+                  read-only.bind="readOnly"
+                  error.bind="error.PricePerUnit"
+                  format="0,0.00"
+                  options.bind="controlOptions">
+      </au-numeric>
+    </td>
+    <td>
+      <au-numeric value.bind="data.TotalPrice"
+                  read-only.bind="true"
+                  format="0,0.00"
+                  error.bind="error.TotalPrice"
+                  options.bind="controlOptions">
+      </au-numeric>
+    </td>
+    <td class="col-sm-1"
+        if.bind="!readOnly">
+      <button class="btn btn-danger pull-right"
+              click.delegate="onremove(data, $event)">-
+      </button>
+    </td>
+  </tr>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/template/item.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/template/item.js
@@ -1,0 +1,62 @@
+import { bindable, computedFrom, BindingSignaler, inject } from 'aurelia-framework';
+var UomLoader = require('../../../../loader/uom-loader');
+
+export class Item {
+   @bindable dataUom;
+
+  constructor() {
+  }
+
+  activate(context) {
+    this.data = context.data;
+    this.error = context.error;
+    this.options = context.context.options;
+    this.readOnly = context.options.readOnly;
+
+    this.selectedPricePerUnit = this.data.PricePerUnit || 0;
+    this.selectedQuantity = this.data.Quantity || 0;
+
+     if (this.data.Uom) {
+      this.dataUom = this.data.Uom;
+    }
+
+    this.calculateTotalPrice();
+  }
+
+  calculateTotalPrice() {
+    const quantity = this.data.Quantity || 0;
+    const pricePerUnit = this.data.PricePerUnit || 0;
+    this.data.TotalPrice = Math.round((quantity * pricePerUnit + Number.EPSILON) * 100) / 100;
+    
+    if (this.options.updateTotalPrice) {
+      this.options.updateTotalPrice();
+    }
+  }
+
+  @bindable selectedPricePerUnit;
+  selectedPricePerUnitChanged(newValue, oldValue) {
+    if (newValue) {
+      this.data.PricePerUnit = newValue;
+      this.calculateTotalPrice();
+    }
+  }
+
+  @bindable selectedQuantity;
+  selectedQuantityChanged(newValue, oldValue) {
+    if (newValue) {
+      this.data.Quantity = newValue;
+      this.calculateTotalPrice();
+    }
+  }
+
+  dataUomChanged(newValue) {
+    this.data.Uom = newValue.Unit;
+    this.data.UomId = newValue.Id;
+
+  }
+
+  get uomLoader() {
+      return UomLoader;
+    }
+
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/view.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/view.html
@@ -1,0 +1,114 @@
+<template>
+  <require from="../../../lib/number-format-value-converter.js"></require>
+  <require from="../../../lib/date-format-value-converter.js"></require>
+
+  <au-input-form 
+      title.bind="title" 
+      with.bind="context" 
+      options.bind="formOptions" 
+      edit.call="editCallback($event)" 
+      delete.call="deleteCallback($event)">
+    
+    <div class="row">
+      <div class="col-md-6">
+        <au-textbox 
+            label=""
+            read-only.bind="true"
+            options.bind="controlOptions">
+        </au-textbox>
+        
+       <au-textbox 
+                    label="Nomor Nota Retur" 
+                    value.bind="data.ReturNoteNo" 
+                    error.bind="error.ReturNoteNo" 
+                    read-only.bind="true"
+                    if.bind="(readOnly || isEdit)"
+                    options.bind="controlOptions">
+                </au-textbox>
+
+                <au-datepicker 
+                    label="Tgl. Nota Retur" 
+                    value.bind="data.ReturNoteDate" 
+                    error.bind="error.ReturNoteDate" 
+                    read-only.bind="readOnly"
+                    options.bind="controlOptions">
+                </au-datepicker>
+
+                 <au-textbox 
+                    label="Nama Supplier" 
+                    value.bind="data.Supplier.Name" 
+                    error.bind="error.SupplierName" 
+                    read-only.bind="true"
+                    show.bind="data.Supplier"
+                    options.bind="controlOptions">
+                </au-textbox>
+
+                <au-multiline 
+                    label="Alamat Supplier" 
+                    value.bind="data.Supplier.Address" 
+                    error.bind="error.SupplierAddress" 
+                    read-only.bind="true"
+                    show.bind="data.Supplier"
+                    options.bind="controlOptions">
+                </au-multiline>
+
+                 <au-textbox 
+                    label="NPWP Supplier" 
+                    value.bind="data.Supplier.NPWP" 
+                    error.bind="error.SupplierNPWP" 
+                    read-only.bind="true"
+                    show.bind="data.Supplier"
+                    options.bind="controlOptions">
+                </au-textbox>
+
+               <au-textbox 
+                    label="No Faktur" 
+                    value.bind="data.VatNo" 
+                    error.bind="error.VatNo" 
+                    read-only.bind="true"
+                    show.bind="data.Supplier"
+                    options.bind="controlOptions">
+                </au-textbox>
+                
+                 <au-autocomplete label="Mata Uang"
+                       value.bind="currency"
+                       error.bind="error.Currency"
+                       loader.one-time="currencyLoader"
+                       text="Code"
+                       read-only.bind="readOnly"
+                       options.bind="controlOptions">
+                 </au-autocomplete>
+
+                 <au-textbox 
+                    label="Rate" 
+                    value.bind="data.Currency.Rate" 
+                    error.bind="error.Currency.Rate" 
+                    read-only.bind="readOnly"
+                    show.bind="currency && currency.Code !== 'IDR'"
+                    options.bind="controlOptions">
+                </au-textbox>
+                
+                 <au-multiline
+                    label="Keterangan"
+                    value.bind="data.Remarks"
+                    error.bind="error.Remarks"
+                    read-only.bind="readOnly" 
+                    options.bind="controlOptions">
+                </au-multiline>
+      </div>
+    </div>
+
+    <br>
+    <h4>Daftar Item</h4>
+    <au-collection 
+        items.bind="data.Items" 
+        columns.bind="itemsInfo.columns"
+        options.bind="itemsInfo.options"
+        read-only.bind="readOnly"
+        header-template="modules/garment-purchasing/purchasing-retur-note-approval/template/item-header"
+        item-template="modules/garment-purchasing/purchasing-retur-note-approval/template/item"
+        footer-template="modules/garment-purchasing/purchasing-retur-note-approval/template/item-footer">
+    </au-collection>
+    
+  </au-input-form>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note-approval/view.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note-approval/view.js
@@ -1,0 +1,167 @@
+import { inject } from "aurelia-framework";
+import { Router } from "aurelia-router";
+import { Service } from "./service";
+import { Dialog } from "../../../au-components/dialog/dialog";
+import { AuthService } from "aurelia-authentication";
+import { RejectReason } from "./dialog-template/reject-reason";
+import moment from 'moment';
+import numeral from 'numeral';
+import { Base64Helper } from '../../../utils/base-64-coded-helper';
+
+numeral.defaultFormat("0,0.00");
+
+@inject(Router, Service, Dialog, AuthService)
+export class View {
+    readOnly = true;
+    
+    controlOptions = {
+        label: {
+            align: "right",
+            length: 5,
+        },
+        control: {
+            length: 5,
+            align: "right",
+        },
+    };
+    
+    length4 = {
+        label: {
+            align: "left",
+            length: 4
+        }
+    };
+    length6 = {
+        label: {
+            align: "left",
+            length: 6
+        }
+    };
+    length7 = {
+        label: {
+            align: "left",
+            length: 7
+        }
+    };
+
+    formOptions = {
+        cancelText: "Kembali",
+        editText: "Approve",
+        deleteText: "Reject"
+    };
+
+    itemsInfo = {
+        columns: ["Keterangan", "Kuantum", "Satuan","Harga Satuan", "Harga Jual"],
+        options: {}
+    }
+
+    constructor(router, service, dialog, authService) {
+        this.router = router;
+        this.service = service;
+        this.dialog = dialog;
+        this.authService = authService;
+    }
+
+    async activate(params, routeConfig, navigationInstruction) {
+        const instruction = navigationInstruction.getAllInstructions()[0];
+        const parentInstruction = instruction.parentInstruction;
+        this.title = parentInstruction.config.title;
+        const type = parentInstruction.config.settings.type;
+
+        switch (type) {
+            case "gm":
+                this.type = "GeneralManager";
+                break;
+            default: break;
+        }
+
+        if (this.authService.authenticated) {
+            this.me = this.authService.getTokenPayload();
+        }
+        else {
+            this.me = null;
+        }
+
+        var id = params.id;
+        let decoded = Base64Helper.decode(id);
+        id = decoded;
+        this.data = await this.service.getById(id);
+        this.error = {};
+
+        if (!this.itemsInfo.options) {
+            this.itemsInfo.options = {};
+        }
+        this.itemsInfo.options.readOnly = this.readOnly;
+        this.itemsInfo.options.isEdit = true;
+        
+        this.itemsInfo.options.BKPReturnPrice = this.data.BKPReturnPrice || 0;
+        this.itemsInfo.options.OtherTaxBaseAmount = this.data.OtherTaxBaseAmount || 0;
+        this.itemsInfo.options.VatToBeRefunded = this.data.VatToBeRefunded || 0;
+        this.itemsInfo.options.CurrencyCode = (this.data.Currency && this.data.Currency.Code) || '';
+        
+        if (this.data.Currency) {
+            this.currency = this.data.Currency;
+        }
+
+        if (this.data.Supplier) {
+            this.selectedSupplier = this.data.Supplier;
+        }
+
+        this.editCallback = this.approve;
+        this.deleteCallback = this.reject;
+    }
+
+    async bind(context) {
+        this.context = context;
+    }
+
+    list() {
+        this.router.navigateToRoute("list");
+    }
+
+    cancelCallback(event) {
+        this.list();
+    }
+
+    approve(event) {
+        if (confirm("Approve Disposition?")) {
+            const jsonPatch = [
+                { op: "replace", path: `/IsApproved${this.type}`, value: true },
+                { op: "replace", path: `/Approved${this.type}By`, value: this.me.username },
+                { op: "replace", path: `/Approved${this.type}Date`, value: new Date() }
+            ];
+
+            this.service.replace(this.data.Id, jsonPatch)
+                .then(result => {
+                    this.list();
+                })
+                .catch(e => {
+                    this.error = e;
+                    if (e.statusCode === 500) {
+                        alert("Gagal menyimpan, silakan coba lagi!");
+                    }
+                });
+        }
+    }
+
+    reject(event) {
+       this.dialog.show(RejectReason, {message: "Silakan masukkan alasan reject:" })
+        .then(response => {
+        if (!response.wasCancelled) {
+            const reason = response.output;
+            if (!reason || String(reason).trim() === "") {
+            alert('Alasan tidak boleh kosong.');
+            return;
+            }
+            this.service
+            .Rejected(this.data.Id, String(reason).trim())
+            .then((result) => {
+                this.list();
+            })
+            .catch((e) => {
+                this.error = e;
+            });
+        }
+        });
+    }
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note/create.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note/create.html
@@ -1,0 +1,4 @@
+<template>
+    <require from="./data-form"></require>
+    <data-form title="Nota Retur"></data-form>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note/create.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note/create.js
@@ -1,0 +1,50 @@
+import {inject, Lazy} from 'aurelia-framework';
+import {Router} from 'aurelia-router';
+import {Service} from './service';
+import {activationStrategy} from 'aurelia-router';
+
+@inject(Router, Service)
+export class Create {
+    hasCancel = true;
+    hasSave = true;
+
+    constructor(router, service) {
+        this.router = router;
+        this.service = service;
+        this.data = {};
+    }
+    activate(params) {
+
+    }
+    bind() {
+        this.data = { Items: [] };
+        this.error = {};
+    }
+
+    cancel(event) {
+        this.router.navigateToRoute('list');
+    }
+
+    determineActivationStrategy() {
+        return activationStrategy.replace;
+    }
+
+    save(event) {
+        if (this.data.Currency && this.data.Currency.Code === 'IDR') {
+            this.data.Currency.Rate = 1;
+        }
+        
+        this.service.create(this.data)
+            .then(result => {
+                alert("Data berhasil dibuat");
+                this.router.navigateToRoute('create',{}, { replace: true, trigger: true });
+            })
+            .catch(e => {
+                if (e.statusCode === 500) {
+                    alert("Gagal menyimpan, silakan coba lagi!");
+                } else {
+                    this.error = e;
+                }
+            })
+    }
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note/data-form.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note/data-form.html
@@ -1,0 +1,124 @@
+<template>
+    <au-input-form 
+        title.bind="title" 
+        with.bind="context">
+
+        <div class="row">
+            <div class="col-md-6">
+                <au-textbox 
+                    label=""
+                    read-only.bind="true"
+                    options.bind="controlOptions">
+                </au-textbox>
+                
+                <au-textbox 
+                    label="Nomor Nota Retur" 
+                    value.bind="data.ReturNoteNo" 
+                    error.bind="error.ReturNoteNo" 
+                    read-only.bind="true"
+                    if.bind="(readOnly || isEdit)"
+                    options.bind="controlOptions">
+                </au-textbox>
+
+                <au-datepicker 
+                    label="Tgl. Nota Retur" 
+                    value.bind="data.ReturNoteDate" 
+                    error.bind="error.ReturNoteDate" 
+                    read-only.bind="readOnly"
+                    options.bind="controlOptions">
+                </au-datepicker>
+
+                <au-autocomplete 
+                    label="Nama Supplier" 
+                    value.bind="selectedSupplier" 
+                    error.bind="error.Supplier" 
+                    loader.bind="supplierLoader" 
+                    query.bind="supplierQuery" 
+                    text.bind="supplierView" 
+                    placeholder="cari supplier" 
+                    key="code"
+                    read-only.bind="readOnly" 
+                    options.bind="controlOptions">
+                </au-autocomplete>
+
+                <au-multiline 
+                    label="Alamat Supplier" 
+                    value.bind="data.Supplier.Address" 
+                    error.bind="error.SupplierAddress" 
+                    read-only.bind="true"
+                    show.bind="data.Supplier"
+                    options.bind="controlOptions">
+                </au-multiline>
+
+                 <au-textbox 
+                    label="NPWP Supplier" 
+                    value.bind="data.Supplier.NPWP" 
+                    error.bind="error.SupplierNPWP" 
+                    read-only.bind="true"
+                    show.bind="data.Supplier"
+                    options.bind="controlOptions">
+                </au-textbox>
+
+                <au-autocomplete label="No Faktur"
+                        value.bind="invoice" 
+                        error.bind="error.VatNo" 
+                        loader.bind="invoiceNoteLoader" 
+                        placeholder="cari nomor invoice"
+                        text.bind="garmentInvoiceView" 
+                        query.bind="filter" 
+                        read-only.bind="readOnly" 
+                        if.bind="data.Supplier"
+                        options.bind="controlOptions">
+                </au-autocomplete>
+                
+                 <au-autocomplete label="Mata Uang"
+                       value.bind="currency"
+                       error.bind="error.Currency"
+                       loader.one-time="currencyLoader"
+                       text="Code"
+                       read-only.bind="readOnly"
+                       options.bind="controlOptions">
+                 </au-autocomplete>
+
+                 <au-textbox 
+                    label="Rate" 
+                    value.bind="data.Currency.Rate" 
+                    error.bind="error.Rate" 
+                    read-only.bind="readOnly"
+                    show.bind="currency && currency.Code !== 'IDR'"
+                    options.bind="controlOptions">
+                </au-textbox>
+                
+                 <au-multiline
+                    label="Keterangan"
+                    value.bind="data.Remarks"
+                    error.bind="error.Remarks"
+                    read-only.bind="readOnly" 
+                    options.bind="controlOptions">
+                </au-multiline>
+            </div>
+    </div>
+
+        <au-textbox error.bind="error.Itemscount" read-only.bind="true"></au-textbox>
+
+        <au-collection 
+            items.bind="data.Items" 
+            errors.bind="error.Items"
+            columns.bind="items.columns"
+            options.bind="options"
+            read-only.bind="readOnly" 
+            if.bind="isItem"
+            header-template="modules/garment-purchasing/purchasing-retur-note/template/item-header"
+            item-template="modules/garment-purchasing/purchasing-retur-note/template/item"
+            footer-template="modules/garment-purchasing/purchasing-retur-note/template/item-footer">
+        </au-collection>
+    
+        <div slot="actions" class="btn-group">
+            <button type="button" class="btn btn-default" click.delegate="context.cancel($event)"     if.one-way="context.hasCancel">Kembali</button>
+            <button type="button" class="btn btn-primary" click.delegate="context.edit($event)"    if.bind="context.hasEdit">Ubah</button>
+            <button type="button" class="btn btn-success" click.delegate="context.save($event)"       if.one-way="context.hasSave">Simpan</button>
+            <button type="button" class="btn btn-danger"  click.delegate="context.delete($event)"   if.bind="context.hasDelete">Hapus</button>
+            <button class="btn btn-primary" click.delegate="context.unpost($event)" if.one-way="context.hasUnpost && !data.IsApprovedGeneralManager">Unpost</button>
+        </div>
+  </au-input-form>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note/data-form.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note/data-form.js
@@ -1,0 +1,294 @@
+import {
+  inject,
+  bindable,
+  containerless,
+  computedFrom,
+  BindingEngine,
+  TaskQueue,
+} from "aurelia-framework";
+import { Service } from "./service";
+import { AuthService } from "aurelia-authentication";
+var SupplierLoader = require('../../../loader/garment-supplier-loader');
+var CurrencyLoader = require('../../../loader/currency-loader');
+var InvoiceNoteLoader = require('../../../loader/garment-invoice-note-loader')
+import moment from "moment";
+
+@inject(Service, BindingEngine, AuthService, TaskQueue)
+export class DataForm {
+  @bindable readOnly = false;
+  @bindable data = {};
+  @bindable error = {};
+  @bindable title;
+  @bindable options = {};
+  @bindable invoice;
+  @bindable selectedSupplier;
+
+
+  controlOptions = {
+    label: {
+      align: "right",
+      length: 5,
+    },
+    control: {
+      length: 5,
+      align: "right",
+    },
+  };
+
+  constructor(service, bindingEngine, authService, taskQueue) {
+    this.service = service;
+    this.bindingEngine = bindingEngine;
+    this.authService = authService;
+    this.taskQueue = taskQueue;
+    this._itemSubscriptions = new Map();
+  }
+
+  bind(context) {
+    this.context = context;
+    this.data = this.context.data;
+    this.error = this.context.error;
+    this.isItem = false;
+    this.isEdit = this.data.Id ? true : false;
+
+    if (!this.data.Items) {
+      this.data.Items = [];
+    }
+    
+    this.options.readOnly = this.readOnly;
+    this.options.isEdit = this.isEdit;
+    this.options.add = () => {
+      this.addItems();
+    };
+
+    if (this.data.Currency) {
+      this.currency = this.data.Currency;
+    }
+
+    if (this.data.Supplier) {
+      this.selectedSupplier = this.data.Supplier;
+    }
+
+    this.updateInvoiceFilter();
+    
+    this.options.Rate = (this.data.Currency && this.data.Currency.Rate) || 1;
+    this.options.CurrencyCode = this.currency ? this.currency.Code : null;
+
+    if (!this.isEdit) {
+      this.addItems();
+    }
+
+    this.isItem = this.data.Items && this.data.Items.length > 0;
+
+    // Single subscription for items changes
+    this.itemsSubscription = this.bindingEngine.collectionObserver(this.data.Items).subscribe(() => {
+      this.updateDataFromItems();
+    });
+    
+    this.subscribeToItems();
+    
+    // Initial calculation
+    this.updateDataFromItems();
+  
+  }
+
+  updateDataFromItems() {
+    this.data.BKPReturnPrice = this.itemSum;
+    this.updateTaxCalculations();
+  }
+
+  subscribeToItems() {
+    if (this._itemSubscriptions) {
+      this._itemSubscriptions.forEach(sub => sub.dispose());
+      this._itemSubscriptions.clear();
+    }
+    
+    if (this.data.Items) {
+      this.data.Items.forEach((item, index) => {
+        const subscription = this.bindingEngine.propertyObserver(item, 'TotalPrice').subscribe(() => {
+          this.updateDataFromItems();
+        });
+        this._itemSubscriptions.set(index, subscription);
+      });
+    }
+  }
+
+  addItems() {
+    if (!this.data.Items) {
+      this.data.Items = [];
+    }
+    var item = { 
+      Quantity: 0,
+      TotalPrice: 0,
+      PricePerUnit: 0,
+      IsNew: true
+    };
+    this.data.Items.push(item);
+    this.subscribeToItems();
+  }
+
+
+
+  get items() {
+    return { 
+      columns: ["Keterangan", "Kuantum", "Satuan","Harga Satuan", "Harga Jual"] 
+    };
+  }
+
+  @computedFrom('data.Items')
+  get itemSum() {
+    if (this.data.Items && this.data.Items.length > 0) {
+      return this.data.Items.reduce((sum, item) => sum + (item.TotalPrice || 0), 0);
+    }
+    return 0;
+  }
+
+
+  updateTaxCalculations() {
+    const rate = (this.data.Currency && this.data.Currency.Rate) || 1;
+    const currencyCode = this.options.CurrencyCode || (this.currency ? this.currency.Code : null);
+    let taxBase = 0;
+    
+    if (currencyCode === 'IDR') {
+      taxBase = (11/12) * this.itemSum;
+    } else {
+      taxBase = (11/12) * (rate * this.itemSum);
+    }
+    
+    const vatReturn = taxBase * 0.12;
+    
+    this.data.OtherTaxBaseAmount = taxBase;
+    this.data.VatToBeRefunded = vatReturn;
+    this.options.OtherTaxBaseAmount = taxBase;
+    this.options.VatToBeRefunded = vatReturn;
+  }
+
+  @bindable currency;
+  currencyChanged(n, o) {
+    const isEdit = !!this.data.Id;
+    if (this.currency) {
+      this.data.Currency = {
+        Id: this.currency.Id,
+        Code: this.currency.Code,
+        Description: this.currency.Description,
+        Symbol: this.currency.Symbol,
+        Rate: isEdit && this.data.Currency
+              ? this.data.Currency.Rate
+              : null
+      };
+
+      this.options.CurrencyCode = this.currency.Code;
+      
+      this.subscribeToRate();
+      this.taskQueue.queueMicroTask(() => {
+        this.updateTaxCalculations();
+      });
+    } else {
+      this.data.Currency = null;
+    }
+  }
+
+  subscribeToRate() {
+    if (this.rateSubscription) {
+      this.rateSubscription.dispose();
+    }
+    
+    if (this.data.Currency) {
+      this.rateSubscription = this.bindingEngine.propertyObserver(this.data.Currency, 'Rate').subscribe(() => {
+        this.options.Rate = (this.data.Currency && this.data.Currency.Rate) || 1;
+        this.taskQueue.queueMicroTask(() => {
+          this.updateTaxCalculations();
+        });
+      });
+    } else {
+      this.rateSubscription = null;
+    }
+  }
+
+  attached() {
+    this.subscribeToRate();
+    
+    if (this.data.VatNo && this.data.Supplier) {
+      this.taskQueue.queueMicroTask(() => {
+        this.invoice = {
+          vatNo: this.data.VatNo,
+          supplier: {
+            Name: this.data.Supplier.Name
+          }
+        };
+      });
+    }
+  }
+
+
+  async selectedSupplierChanged(newValue) {
+    if (newValue && (newValue.Id || newValue.id)) {
+      if (!this.data.Supplier) {
+        this.data.Supplier = {};
+      }
+      this.data.Supplier.Code = newValue.code || newValue.Code;
+      this.data.Supplier.Name = newValue.name || newValue.Name;
+      this.data.Supplier.Id = newValue.Id || newValue.id;
+      this.data.Supplier.Address = newValue.address || newValue.Address;
+      this.data.Supplier.NPWP = newValue.NPWP;
+      
+      this.invoice = null;
+      this.updateInvoiceFilter();
+    } else {
+      this.data.Supplier = null;
+      this.invoice = null;
+      this.filter = {};
+    }
+  }
+
+  
+  invoiceChanged(newValue) {
+    if (newValue && newValue.vatNo) {
+      this.data.VatNo = newValue.vatNo || this.data.VatNo;
+    }
+  }
+
+  updateInvoiceFilter() {
+    const supplierId = (this.data.Supplier && (this.data.Supplier.Id || this.data.Supplier.id)) || this.options.supplierId;
+    
+    this.filter = supplierId ? {
+      "supplierId": supplierId,
+      "IsDeleted": false
+    } : {};
+  }
+
+  get supplierLoader() {
+    return SupplierLoader;
+  }
+
+  get invoiceNoteLoader() {
+    return InvoiceNoteLoader;
+  }
+
+  garmentInvoiceView = (gInvoices) => {
+    return `${gInvoices.vatNo} - ${gInvoices.supplier.Name}`;
+  }
+
+  supplierView = (supplier) => {
+    const code = supplier.code || supplier.Code;
+    const name = supplier.name || supplier.Name;
+    return `${code} - ${name}`
+  }
+
+  get currencyLoader() {
+    return CurrencyLoader;
+  }
+
+  unbind() {
+    if (this.itemsSubscription) {
+      this.itemsSubscription.dispose();
+    }
+    if (this.rateSubscription) {
+      this.rateSubscription.dispose();
+    }
+    if (this._itemSubscriptions) {
+      this._itemSubscriptions.forEach(sub => sub.dispose());
+      this._itemSubscriptions.clear();
+    }
+  }
+
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note/edit.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note/edit.html
@@ -1,0 +1,6 @@
+<template>
+  <require from="./data-form"></require>
+  <data-form 
+      title="Nota Retur">
+  </data-form>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note/edit.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note/edit.js
@@ -1,0 +1,54 @@
+import { inject, Lazy } from 'aurelia-framework';
+import { Router } from 'aurelia-router';
+import { Service } from './service';
+import { Base64Helper } from '../../../utils/base-64-coded-helper';
+
+
+@inject(Router, Service)
+export class Edit {
+    hasCancel = true;
+    hasSave = true;
+
+    constructor(router, service) {
+        this.router = router;
+        this.service = service;
+    }
+
+    bind() {
+        this.error = {};
+    }
+
+    async activate(params) {
+        var id = params.id;
+        let decoded = Base64Helper.decode(id);
+        id = decoded;
+        this.data = await this.service.getById(id);
+        
+
+        if (this.data.Items) {
+            for (let item of this.data.Items) {
+                item.IsSave = true;
+                item.IsDisabled = false;
+            }
+        }
+
+    }
+
+    cancel(event) {
+        const encoded = Base64Helper.encode(this.data.Id);
+        this.router.navigateToRoute('view', { id: encoded });
+    }
+
+    save(event) {
+        if (this.data.Currency && this.data.Currency.Code === 'IDR') {
+            this.data.Currency.Rate = 1;
+        }
+        
+        this.service.update(this.data).then(result => {
+            this.cancel();
+        }).catch(e => {
+            this.error = e;
+        })
+    }
+}
+

--- a/src/modules/garment-purchasing/purchasing-retur-note/index.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note/index.html
@@ -1,0 +1,5 @@
+<template> 
+  <div> 
+    <router-view></router-view>
+  </div>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note/index.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note/index.js
@@ -1,0 +1,12 @@
+export class Index {
+    configureRouter(config, router) {
+        config.map([
+            { route: ['', 'list'], moduleId: './list', name: 'list', nav: false, title: 'List: Nota Retur' },
+            { route: 'create', moduleId: './create', name: 'create', nav: false, title: 'Create: Nota Retur' },
+            { route: 'view/:id', moduleId: './view', name: 'view', nav: false, title: 'View: Nota Retur' },
+            { route: 'edit/:id', moduleId: './edit', name: 'edit', nav: false, title: 'Edit: Nota Retur' },
+        ]);
+
+        this.router = router;
+    }
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note/list.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note/list.html
@@ -1,0 +1,21 @@
+<template>
+    <h1 class="page-header">Nota Retur </h1>
+    <au-table 
+        view-model.ref="table" 
+        data.bind="loader" 
+        columns.bind="columns" 
+        sortable.bind="true" 
+        page-size="25" 
+        context.bind="context"
+        context-click.delegate="contextClickCallback($event)" 
+        context-show.call="contextShowCallback(index, context, data)"
+        selectable.bind="true" 
+        selections.bind="dataToBePosted" 
+        row-formatter.bind="rowFormatter">
+            
+        <div slot="toolbar" class="btn-group">
+            <button class="btn btn-success" click.delegate="create()">Buat</button>
+             <button class="btn btn-primary" disabled.bind="!dataToBePosted.length > 0" click.delegate="posting()">Posting</button>
+        </div>
+    </au-table>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note/list.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note/list.js
@@ -1,0 +1,115 @@
+import { inject } from 'aurelia-framework';
+import { Service } from "./service";
+import { Router } from 'aurelia-router';
+import moment from 'moment';
+import { Base64Helper } from '../../../utils/base-64-coded-helper';
+
+@inject(Router, Service)
+export class List {
+    dataToBePosted = [];
+
+    context = ["Rincian", "Cetak PDF"]
+
+    columns = [
+
+        {
+            field: "isPosting", title: "Post", checkbox: true, sortable: false,
+            formatter: function (value, data, index) {
+                this.checkboxEnabled = !data.IsPosted;
+                return ""
+            }
+         },
+        
+        { field: "ReturNoteNo", title: "Nomer Nota Retur" },
+       
+        {
+            field: "ReturNoteDate", title: "Tanggal Nota Retur", formatter: function (value, data, index) {
+                return moment(value).format("DD MMM YYYY");
+            }
+        },
+        { field: "SupplierName", title: "Nama Supplier" },
+        { field: "BKPReturnPrice", title: "Jumlah Harga Jual BKP" },
+        { field: "IsPostedLabel", title: "Status Posting" },
+        { field: "IsApprovedGMLabel", title: "Approval GM Purchasing" },
+        { field: "ReasonRejected", title: "Alasan Reject" }
+    ];
+
+    rowFormatter(data, index) {
+        if (data.ReasonRejected) {
+            return { classes: "" };
+        } else if (data.IsApprovedGeneralManager) {
+            return { classes: "success" };
+        } else {
+            return { classes: "danger" };
+        }
+    }
+
+    loader = (info) => {
+        var order = {};
+        if (info.sort)
+            order[info.sort] = info.order;
+        var arg = {
+            page: parseInt(info.offset / info.limit, 10) + 1,
+            size: info.limit,
+            keyword: info.search,
+            order: order,
+        }
+
+        return this.service.search(arg)
+            .then(result => {
+                result.data.map(data => {
+                    data.IsPostedLabel  = data.IsPosted ? "SUDAH" : "BELUM";
+                    data.SupplierName = data.Supplier ? data.Supplier.Name : "";
+                    data.IsApprovedGMLabel = data.IsApprovedGeneralManager ? "SUDAH" : "BELUM";
+                    return data;
+                });
+                return {
+                    total: result.info.total,
+                    data: result.data
+                }
+            });
+    }
+
+    constructor(router, service) {
+        this.service = service;
+        this.router = router;
+    }
+
+   
+    contextClickCallback(event) {
+        var arg = event.detail;
+        var data = arg.data;
+        const encoded = Base64Helper.encode(data.Id);
+        switch (arg.name) {
+            case "Rincian":
+                this.router.navigateToRoute('view', { id: encoded });
+                break;
+            case "Cetak PDF":
+                this.service.getPdfById(data.Id);
+                break;
+        }
+    }
+
+    contextShowCallback(index, name, data) {
+        switch (name) {
+            case "Cetak PDF":
+                return data.Id;
+            default:
+                return true;
+        }
+    }
+
+    create() {
+        this.router.navigateToRoute('create');
+    }
+
+    posting() {
+        if (this.dataToBePosted.length > 0) {
+        this.service.post(this.dataToBePosted).then(result => {
+            this.table.refresh();
+        }).catch(e => {
+            this.error = e;
+        })
+        }
+    }
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note/service.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note/service.js
@@ -1,0 +1,62 @@
+import { inject, Lazy } from 'aurelia-framework';
+import { HttpClient } from 'aurelia-fetch-client';
+import { RestService } from '../../../utils/rest-service';
+import { Container } from 'aurelia-dependency-injection';
+import { Config } from "aurelia-api";
+import moment from 'moment';
+
+const serviceUri = 'garment-retur-note';
+
+
+
+export class Service extends RestService {
+
+    constructor(http, aggregator, config, endpoint) {
+        super(http, aggregator, config, "purchasing-azure");
+    }
+
+    search(info) {
+        var endpoint = `${serviceUri}/by-user`;
+        return super.list(endpoint, info);
+    }
+
+    getById(id) {
+        var endpoint = `${serviceUri}/${id}`;
+        return super.get(endpoint);
+    }
+
+    create(data) {
+        var endpoint = `${serviceUri}`;
+        return super.post(endpoint, data);
+    }
+
+    update(data) {
+        var endpoint = `${serviceUri}/${data.Id}`;
+        return super.put(endpoint, data);
+    }
+
+    delete(data) {
+        var endpoint = `${serviceUri}/${data.Id}`;
+        return super.delete(endpoint, data);
+    }
+
+    getPdfById(id) {
+        var endpoint = `${serviceUri}/${id}`;
+        return super.getPdf(endpoint);
+    }
+
+    post(data) {
+        var endpoint = `${serviceUri}/post`;
+        return super.post(endpoint, data);
+    }
+
+    unpost(id) {
+        var endpoint = `${serviceUri}/unpost/${id}`;
+        return super.put(endpoint);
+    }
+
+ 
+}
+
+
+

--- a/src/modules/garment-purchasing/purchasing-retur-note/template/item-footer.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note/template/item-footer.html
@@ -1,0 +1,41 @@
+<template>
+  <tr>
+    <td colspan="3" class="text-right" style="padding-right:10%">
+      Jumlah Harga Jual BKP yang dikembalikan
+    </td>
+    <td>
+      <au-textbox value.one-way="currency" error.bind="error.currency" read-only.bind="true"></au-textbox>
+    </td>
+    <td colspan.bind="readOnly ? 1 : 2" class="text-left">
+      <require from="../../../../lib/number-format-value-converter"></require>
+      ${itemSum | numberFormat:"0,000.00"}
+    </td>
+    
+  </tr>
+  <tr>
+    <td colspan="3" class="text-right" style="padding-right:10%">
+      Dasar Pengenaan Pajak Nilai Lain
+    </td>
+    <td>
+      <au-textbox value="IDR" read-only.bind="true"></au-textbox>
+    </td>
+    <td colspan.bind="readOnly ? 1 : 2" class="text-left">
+      <require from="../../../../lib/number-format-value-converter"></require>
+      ${otherTaxBaseAmount | numberFormat:"0,000.00"}
+    </td>
+    
+  </tr>
+  <tr>
+    <td colspan="3" class="text-right" style="padding-right:10%">
+      PPN yang diminta kembali
+    </td>
+    <td>
+      <au-textbox value="IDR" read-only.bind="true"></au-textbox>
+    </td>
+    <td colspan.bind="readOnly ? 1 : 2" class="text-left">
+      <require from="../../../../lib/number-format-value-converter"></require>
+      ${vatToBeRefunded | numberFormat:"0,000.00"}
+    </td>
+    
+  </tr>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note/template/item-footer.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note/template/item-footer.js
@@ -1,0 +1,48 @@
+import { inject, bindable, computedFrom } from 'aurelia-framework';
+import { Container } from 'aurelia-dependency-injection';
+import { Config } from "aurelia-api"
+
+export class DetailFooter {
+  activate(context) {
+    this.context = context;
+  }
+
+  get currency(){
+    return this.context.options.CurrencyCode;
+
+  }
+
+  get itemSum() {
+    var qty = this.context.items
+      .map((item) => item.data.TotalPrice || 0);
+    return qty
+      .reduce((prev, curr, index) => { return prev + curr }, 0);
+  }
+
+  get rate() {
+    return this.context.options.Rate || 1;
+  }
+
+  get otherTaxBaseAmount() {
+    if (this.context.options.OtherTaxBaseAmount !== undefined && this.context.options.OtherTaxBaseAmount !== null) {
+      return this.context.options.OtherTaxBaseAmount;
+    }
+   
+    if (this.currency === 'IDR') {
+      return (11/12) * this.itemSum;
+    } else {
+      return (11/12) * (this.rate * this.itemSum);
+    }
+  }
+
+  get vatToBeRefunded() {
+  
+    if (this.context.options.VatToBeRefunded !== undefined && this.context.options.VatToBeRefunded !== null) {
+      return this.context.options.VatToBeRefunded;
+    }
+
+    return this.otherTaxBaseAmount * 0.12;
+  }
+
+
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note/template/item-header.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note/template/item-header.html
@@ -1,0 +1,8 @@
+<template >
+    <tr>
+        <th repeat.for="column of columns">
+            <label>${column}</label>
+        </th>
+        <th if.bind="!readOnly" style="width: 75px;"><button type="button" click.delegate="addItem()" class="btn btn-success btn-sm">+</button></th>
+    </tr>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note/template/item-header.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note/template/item-header.js
@@ -1,0 +1,27 @@
+import { inject } from 'aurelia-framework';
+
+@inject(Element)
+export default class DebetNoteHeader {
+
+  constructor(element) {
+    this.element = element;
+  }
+
+  activate(context) {
+    this.context = context;
+    this.data = context.data;
+    this.items = context.items;
+    this.options = context.options;
+    this.readOnly = this.options.readOnly;
+  }
+
+  addItem() {
+    if (
+      this.context &&
+      this.context.options &&
+      typeof this.context.options.add === 'function'
+    ) {
+      this.context.options.add();
+    }
+  }
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note/template/item.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note/template/item.html
@@ -1,0 +1,54 @@
+<template>
+  <tr>
+    <td>
+      <au-multiline value.bind="data.Description"
+                  error.bind="error.Description"
+                  placeholder="Keterangan"
+                  read-only.bind="readOnly"
+                  options.bind="controlOptions">
+      </au-multiline>
+    </td>
+    <td>
+      <au-numeric 
+          value.bind="selectedQuantity"
+          read-only.bind="readOnly"
+          error.bind="error.Quantity"
+          options.bind="controlOptions">
+      </au-numeric>
+    </td>
+    <td>
+            <au-autocomplete 
+                value.bind="dataUom" 
+                error.bind="error.Uom"
+                loader.bind="uomLoader"
+                placeholder="cari satuan" 
+                text="Unit"
+                key="Id"
+                read-only.bind="readOnly"
+                options.bind="controlOptions">
+            </au-autocomplete>
+        </td>
+    <td>
+      <au-numeric value.bind="selectedPricePerUnit"
+                  read-only.bind="readOnly"
+                  error.bind="error.PricePerUnit"
+                  format="0,0.00"
+                  options.bind="controlOptions">
+      </au-numeric>
+    </td>
+    <td>
+      <au-numeric value.bind="data.TotalPrice"
+                  read-only.bind="true"
+                  format="0,0.00"
+                  error.bind="error.TotalPrice"
+                  options.bind="controlOptions">
+      </au-numeric>
+    </td>
+    <td class="col-sm-1"
+        if.bind="!readOnly">
+      <button class="btn btn-danger pull-right"
+              click.delegate="onremove(data, $event)">-
+      </button>
+    </td>
+  </tr>
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note/template/item.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note/template/item.js
@@ -1,0 +1,70 @@
+import { bindable, computedFrom, BindingSignaler, inject } from 'aurelia-framework';
+var UomLoader = require('../../../../loader/uom-loader');
+
+export class Item {
+   @bindable dataUom;
+
+  constructor() {
+  }
+
+  activate(context) {
+    this.data = context.data;
+    this.error = context.error;
+    this.options = context.context.options;
+    this.readOnly = context.options.readOnly;
+
+    this.selectedPricePerUnit = this.data.PricePerUnit || 0;
+    this.selectedQuantity = this.data.Quantity || 0;
+
+     if (this.data.Uom) {
+      this.dataUom = this.data.Uom;
+    }
+
+    this.calculateTotalPrice();
+  }
+
+  calculateTotalPrice() {
+    const quantity = this.data.Quantity || 0;
+    const pricePerUnit = this.data.PricePerUnit || 0;
+    this.data.TotalPrice = Math.round((quantity * pricePerUnit + Number.EPSILON) * 100) / 100;
+    
+    if (this.options.updateTotalPrice) {
+      this.options.updateTotalPrice();
+    }
+  }
+
+  @bindable selectedPricePerUnit;
+  selectedPricePerUnitChanged(newValue) {
+    this.data.PricePerUnit = Number(newValue != null ? newValue : 0);
+    this.calculateTotalPrice();
+  }
+  // selectedPricePerUnitChanged(newValue, oldValue) {
+  //   if (newValue) {
+  //     this.data.PricePerUnit = newValue;
+  //     this.calculateTotalPrice();
+  //   }
+  // }
+
+  @bindable selectedQuantity;
+ selectedQuantityChanged(newValue) {
+    this.data.Quantity = Number(newValue != null ? newValue : 0);
+    this.calculateTotalPrice();
+  }
+  // selectedQuantityChanged(newValue, oldValue) {
+  //   if (newValue) {
+  //     this.data.Quantity = newValue;
+  //     this.calculateTotalPrice();
+  //   }
+  // }
+
+  dataUomChanged(newValue) {
+    this.data.Uom = newValue.Unit;
+    this.data.UomId = newValue.Id;
+
+  }
+
+  get uomLoader() {
+      return UomLoader;
+    }
+
+}

--- a/src/modules/garment-purchasing/purchasing-retur-note/view.html
+++ b/src/modules/garment-purchasing/purchasing-retur-note/view.html
@@ -1,0 +1,7 @@
+<template>
+  <require from="./data-form"></require>
+  <data-form 
+      title="Nota Retur" 
+      read-only="true">
+  </data-form> 
+</template>

--- a/src/modules/garment-purchasing/purchasing-retur-note/view.js
+++ b/src/modules/garment-purchasing/purchasing-retur-note/view.js
@@ -1,0 +1,82 @@
+import { inject, Lazy } from "aurelia-framework";
+import { Router } from "aurelia-router";
+import { Service } from "./service";
+import { Base64Helper } from '../../../utils/base-64-coded-helper';
+
+@inject(Router, Service)
+export class View {
+  hasCancel = true;
+  hasEdit = true;
+  hasDelete = true;
+  hasUnpost = false;
+  dispoId = "";
+
+  constructor(router, service) {
+    this.router = router;
+    this.service = service;
+  }
+  async activate(params) {
+    var id = params.id;
+    let decoded = Base64Helper.decode(id);
+    this.dispoId = decoded;
+    id = decoded;
+    this.data = await this.service.getById(id);
+    
+    if (!this.data.IsPosted) {
+            this.hasEdit = true;
+            this.hasDelete = true;
+        } else {
+            if (!this.data.IsUsed) {
+                this.hasUnpost = true;
+            }
+        }
+
+    if (this.hasUnpost) {
+        this.hasEdit = false;
+        this.hasDelete = false;
+    }
+
+    if (this.data.Items) {
+      for (let item of this.data.Items) {
+        item.IsSave = true;
+      }
+    }
+  
+
+    if (this.data.IsReceived) {
+      this.hasEdit = false;
+      this.hasDelete = false;
+    }
+  }
+
+  cancel(event) {
+    var r = confirm("Apakah anda yakin akan keluar?");
+    if (r == true) {
+      this.router.navigateToRoute("list");
+    }
+  }
+
+  edit(event) {
+    const encoded = Base64Helper.encode(this.data.Id);
+    var r = confirm("Apakah anda yakin akan mengubah data ini?");
+    if (r == true) {
+      this.router.navigateToRoute("edit", { id: encoded });
+    }
+  }
+
+  delete(event) {
+    var r = confirm("Apakah anda yakin akan menghapus data ini?");
+    if (r == true) {
+      this.service.delete(this.data).then((result) => {
+        this.cancel();
+      });
+    }
+  }
+  unpost(event) {
+        this.service.unpost(this.dispoId).then(result => {
+            this.cancel();
+        }).catch(e => {
+            this.error = e;
+        })
+    }
+}

--- a/src/routes/garment-purchasing.js
+++ b/src/routes/garment-purchasing.js
@@ -1381,4 +1381,71 @@ module.exports = [
       iconClass: "fa fa-dashboard",
     },
   },
+  {
+    route: "/garment/purchasing-debet-note",
+    name: "purchasing-debet-note",
+    moduleId:
+      "./modules/garment-purchasing/purchasing-debet-note/index",
+    nav: true,
+    title: "Nota Debet",
+    auth: true,
+    settings: {
+      group: "g-purchasing",
+      subGroup: "transaksi",
+      // permission: { "C9": 1, "C1B": 1, "C1A": 1, "C2C": 1, "C2B": 1, "C2A": 1 },
+      permission: { H73: 1 },
+      iconClass: "fa fa-dashboard",
+    },
+  },
+   {
+        //pinjam permission
+        route: '/garment/purchasing-debet-note-approval/gm',
+        name: 'purchasing-debet-note-approval-gm',
+        moduleId: './modules/garment-purchasing/purchasing-debet-note-approval/index',
+        nav: true,
+        title: 'Debet Note Approval - GM Purchasing',
+        auth: true,
+        settings: {
+            group: "g-purchasing",
+            subGroup: "approval",
+            // permission: { "PGA": 1, "C7": 1, "C9": 1 },
+            permission: { H75 : 1 },
+            iconClass: 'fa fa-calculator',
+            type: "gm"
+        }
+    },
+    {
+    route: "/garment/purchasing-retur-note",
+    name: "purchasing-retur-note",
+    moduleId:
+      "./modules/garment-purchasing/purchasing-retur-note/index",
+    nav: true,
+    title: "Nota Retur",
+    auth: true,
+    settings: {
+      group: "g-purchasing",
+      subGroup: "transaksi",
+      // permission: { "C9": 1, "C1B": 1, "C1A": 1, "C2C": 1, "C2B": 1, "C2A": 1 },
+      permission: { H74: 1 },
+      iconClass: "fa fa-dashboard",
+    },
+  },
+  {
+        //pinjam permission
+        route: '/garment/purchasing-retur-note-approval/gm',
+        name: 'purchasing-retur-note-approval-gm',
+        moduleId: './modules/garment-purchasing/purchasing-retur-note-approval/index',
+        nav: true,
+        title: 'Retur Note Approval - GM Purchasing',
+        auth: true,
+        settings: {
+            group: "g-purchasing",
+            subGroup: "approval",
+            // permission: { "PGA": 1, "C7": 1, "C9": 1 },
+            permission: { H76 : 1 },
+            iconClass: 'fa fa-calculator',
+            type: "gm"
+        }
+    },
+
 ];


### PR DESCRIPTION
Introduce new garment-purchasing features for Debet and Retur notes: adds modules for list/create/edit/view, data forms, collection item/header/footer templates, approval flows with reject-reason dialog, services (REST integration), and utility usage (moment, numeral, Base64 helper). Also includes router/index files for these modules and updates to src/routes/garment-purchasing.js to integrate the new routes.