### PR TITLE
Add idle timeout, changepass UI and password rule - SPRINT 5

### DIFF
--- a/src/changepass.js
+++ b/src/changepass.js
@@ -25,6 +25,15 @@ export class ChangePass {
         this.username = params.Username;
     }
 
+    attached() {
+        // Disable sidebar saat halaman changepass dibuka (class)
+        const sidebars = document.getElementsByClassName('side-nav-bar');
+        for (let sidebar of sidebars) {
+            sidebar.style.pointerEvents = 'none';
+            //sidebar.style.opacity = '0.5'; // efek visual agar terlihat disabled
+        }
+    }
+
     save() {
         this.error = false;
         this.disabledButton = true;
@@ -43,7 +52,14 @@ export class ChangePass {
                 this.service.updatePass(this.data)
                     .then(result => {
                         alert("Kata Sandi Berhasil DiUbah");
+                        // Enable sidebar kembali setelah password berhasil diubah (class)
+                        // const sidebars = document.getElementsByClassName('side-nav-bar');
+                        // for (let sidebar of sidebars) {
+                        //     sidebar.style.pointerEvents = '';
+                        //     sidebar.style.opacity = '';
+                        // }
                         this.authService.logout("#/login");
+                        window.location.reload();
                     })
                     .catch(e => {
                         this.error = e;
@@ -89,4 +105,4 @@ export class ChangePass {
 
     //     return null; // Password valid
     // }
-} 
+}

--- a/src/login.js
+++ b/src/login.js
@@ -2,6 +2,7 @@ import { Aurelia, inject } from 'aurelia-framework';
 import { AuthService } from "aurelia-authentication";
 import '../styles/signin.css';
 import JSEncrypt from 'jsencrypt';
+import { PasswordValidator } from './utils/password-validator';
 
 @inject(AuthService)
 export class Login {
@@ -58,6 +59,14 @@ export class Login {
         return this.authService.login({ authEncrypted })
             .then(response => {
                 console.log("success logged " + response);
+                this.statusMessage = PasswordValidator.validate(this.password);
+                
+                if (this.statusMessage) {
+                    alert(this.statusMessage);
+                    this.disabledButton = false;
+                    window.location.href = `#/changepass?Username=${this.username}`;
+                }
+                
                 // location.reload();
             })
             .catch(err => {

--- a/src/main.js
+++ b/src/main.js
@@ -9,10 +9,148 @@ import '../styles/dashboard.css';
 import '../styles/splash-screen.css';
 import 'bootstrap';
 import authConfig from "../auth-config";
+import { Config } from "aurelia-api";
+import { AuthService } from 'aurelia-authentication';
+let authService;
 
 // comment out if you don't want a Promise polyfill (remove also from webpack.common.js)
 import * as Bluebird from 'bluebird';
 Bluebird.config({ warnings: false });
+
+// === Idle Timeout / Auto-Logout ===
+const IDLE_TIMEOUT_MINUTES = 1;
+let idleTimer;
+let warningTimer;
+let warningPopup;
+let countdownInterval;
+
+let idleEvents = ['mousemove', 'keydown', 'mousedown', 'touchstart', 'scroll'];
+let warningActive = false;
+
+function enableIdleEvents() {
+    if (!idleEventsActive) {
+        idleEvents.forEach(event => {
+            window.addEventListener(event, resetIdleTimer);
+        });
+        idleEventsActive = true;
+    }
+}
+
+function disableIdleEvents() {
+    if (idleEventsActive) {
+        idleEvents.forEach(event => {
+            window.removeEventListener(event, resetIdleTimer);
+        });
+        idleEventsActive = false;
+    }
+}
+
+// function updateLastLogin() {
+//     console.log(authService);
+//     console.log(authEndpoint);
+//     if (authEndpoint && authService) {
+//         authEndpoint.update('me', null, {})
+//             .then(() => {
+//                 authService.getMe()
+//                     .then((result) => {
+//                         // result.data berisi user terbaru
+//                         // Jika ingin update state global, tambahkan di sini
+//                         resetIdleTimer();
+//                     });
+//             })
+//             .catch((error) => {
+//                 console.error('Error updating last login time:', error);
+//                 resetIdleTimer(); // Tetap reset timer meski gagal
+//             });
+//     } else {
+//         resetIdleTimer();
+//     }
+// }
+
+
+function showWarningPopup() {
+    // Jangan tampilkan popup jika sudah di halaman login
+    if (window.location.hash.indexOf('#/login') !== -1) return;
+    // Jika popup sudah ada, jangan buat lagi
+    if (document.getElementById('idle-warning-popup')) return;
+    warningActive = true;
+    let secondsLeft = 18000; // 5 jam dalam detik
+    warningPopup = document.createElement('div');
+    warningPopup.id = 'idle-warning-popup';
+    warningPopup.style.position = 'fixed';
+    warningPopup.style.top = '0';
+    warningPopup.style.left = '0';
+    warningPopup.style.width = '100vw';
+    warningPopup.style.height = '100vh';
+    warningPopup.style.background = 'rgba(0,0,0,0.3)';
+    warningPopup.style.display = 'flex';
+    warningPopup.style.justifyContent = 'center';
+    warningPopup.style.alignItems = 'center';
+    warningPopup.style.zIndex = '9999';
+    warningPopup.innerHTML = `
+        <div style="background:white;padding:32px;border-radius:8px;box-shadow:0 2px 8px #0003;text-align:center;">
+            <h3>Anda akan logout otomatis dalam <span id="idle-countdown">${formatDuration(secondsLeft)}</span></h3>
+            <p>Silakan klik tombol di bawah jika Anda masih aktif.</p>
+            <button class="btn btn-primary" id="idle-warning-btn" style="padding:8px 24px;font-size:16px;">I'm here</button>
+        </div>
+    `;
+    document.body.appendChild(warningPopup);
+    document.getElementById('idle-warning-btn').onclick = () => {
+        resetIdleTimer();
+        hideWarningPopup();
+    };
+    countdownInterval = setInterval(() => {
+        secondsLeft--;
+        const countdownSpan = document.getElementById('idle-countdown');
+        if (countdownSpan) countdownSpan.textContent = formatDuration(secondsLeft);
+        if (secondsLeft <= 0) {
+            clearInterval(countdownInterval);
+            hideWarningPopup();
+            // Logout otomatis
+            if (authService) {
+                authService.logout().then(() => {
+                    window.location.href = '#/login';
+                });
+            } else {
+                window.localStorage.clear();
+                window.location.href = '#/login';
+            }
+        }
+    }, 1000);
+}
+
+function formatDuration(seconds) {
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+}
+
+function hideWarningPopup() {
+    if (warningPopup) {
+        warningPopup.remove();
+        warningPopup = null;
+    }
+    clearInterval(countdownInterval);
+    warningActive = false;
+}
+
+function resetIdleTimer() {
+    clearTimeout(idleTimer);
+    clearTimeout(warningTimer);
+    if (warningActive) return; // Jangan reset timer jika popup warning sedang tampil
+    hideWarningPopup();
+    idleTimer = setTimeout(() => {
+        showWarningPopup(); // Munculkan popup setelah 15 menit
+    }, IDLE_TIMEOUT_MINUTES * 60 * 1000);
+}
+
+function setupIdleTimeout() {
+    idleEvents.forEach(event => {
+        window.addEventListener(event, resetIdleTimer);
+    });
+    resetIdleTimer();
+}
 
 export async function configure(aurelia) {
     aurelia.use
@@ -20,7 +158,6 @@ export async function configure(aurelia) {
         .feature('au-components')
         .feature('components')
         .feature('converters')
-
         .plugin("aurelia-api", config => {
             var offset = new Date().getTimezoneOffset() / 60 * -1;
             var defaultConfig = {
@@ -61,7 +198,7 @@ export async function configure(aurelia) {
             const garmentShipping = "https://garment-etl-service-dev.azurewebsites.net/api/";
             var ItInven = "https://it-inventory-etl-service-v8.azurewebsites.net/api/";
             var danlirisReport = "https://com-danliris-service-it-inventory.azurewebsites.net/v1/";
-
+            console.log(defaultConfig);
             config.registerEndpoint('auth', auth);
             config.registerEndpoint('core', core);
             config.registerEndpoint('production', production, defaultConfig);
@@ -89,6 +226,7 @@ export async function configure(aurelia) {
         })
         .plugin("aurelia-authentication", baseConfig => {
             baseConfig.configure(authConfig);
+            authService = aurelia.container.get(AuthService);
 
             if (baseConfig.client && baseConfig.client.client) {
                 var offset = new Date().getTimezoneOffset() / 60 * -1;
@@ -162,6 +300,7 @@ export async function configure(aurelia) {
     // aurelia.use.plugin('aurelia-html-import-template-loader')
 
     await aurelia.start();
+    //authEndpoint = aurelia.container.get(Config).getEndpoint('auth');
     aurelia.setRoot('app');
 
     // Mark app as ready for splash screen
@@ -170,6 +309,9 @@ export async function configure(aurelia) {
             window.splashManager.markAppReady();
         }
     }, 1000);
+
+    // Setup idle timeout
+    setupIdleTimeout();
 
     // if you would like your website to work offline (Service Worker), 
     // install and enable the @easy-webpack/config-offline package in webpack.config.js and uncomment the following code:

--- a/src/nav-bar.html
+++ b/src/nav-bar.html
@@ -83,7 +83,7 @@
   </nav>
  
 <!-- OVERLAY -->
-<div show.bind="ConfirmUpdateTimer"
+<!-- <div show.bind="ConfirmUpdateTimer"
      click.trigger.stop
      style="
         position: fixed;
@@ -91,10 +91,10 @@
         background: rgba(0,0,0,0.45);
         z-index: 99998;
      ">
-</div>
+</div> -->
 
 <!-- CONFIRM BOX -->
-<div show.bind="ConfirmUpdateTimer"
+<!-- <div show.bind="ConfirmUpdateTimer"
      click.trigger.stop
      style="
         zoom: 1.2;
@@ -138,10 +138,10 @@
     </div>
 
   </div>
-</div>
+</div> -->
 <!-- END CONFIRM BOX -->
 
-</div>
+<!-- </div> -->
 
 
 </template>

--- a/src/nav-bar.js
+++ b/src/nav-bar.js
@@ -25,9 +25,9 @@ export class NavBar {
             this.authService.getMe()
                 .then((result) => {
                     this.me = result.data;
-                    if (this.me && this.me.expiredDateTime) {
-                        this.startCountdown(this.me.expiredDateTime);
-                    }
+                    // if (this.me && this.me.expiredDateTime) {
+                    //     this.startCountdown(this.me.expiredDateTime);
+                    // }
                 })
         }
         else {
@@ -37,153 +37,155 @@ export class NavBar {
         return this.authService.authenticated;
     }
 
-    updateDataLastTime() {
-        this.authEndpoint.update('me', null, {})
-            .then((result) => {
-                    this.authService.getMe()
-                    .then((result) => {
-                        this.me = result.data;
-                        this.resetCountdownState();
-                        if (this.me && this.me.expiredDateTime) {
-                            this.startCountdown(this.me.expiredDateTime);
-                        }
-                    })
-            })
-            .catch((error) => {
-                console.error('Error updating last login time:', error);
-            });
-    }
-    offConfirmUpdateTimer() {
-        this.ConfirmUpdateTimer = false;
-    }
-    resetCountdownState() {
-        // hentikan countdown lama
-        if (this.countdownTimer) {
-            clearInterval(this.countdownTimer);
-            this.countdownTimer = null;
-        }
+    // updateDataLastTime() {
+    //     this.authEndpoint.update('me', null, {})
+    //         .then((result) => {
+    //                 this.authService.getMe()
+    //                 .then((result) => {
+    //                     this.me = result.data;
+    //                     this.resetCountdownState();
+    //                     if (this.me && this.me.expiredDateTime) {
+    //                         this.startCountdown(this.me.expiredDateTime);
+    //                     }
+    //                 })
+    //         })
+    //         .catch((error) => {
+    //             console.error('Error updating last login time:', error);
+    //         });
 
-        // hentikan blinking
-        this.stopBlinking();
-        this.isWarning = false;
-        this.ConfirmUpdateTimer = false;
-        this.showNotification = false;
-        this.countdown = "";
-    }
+    //      this.authService.updateToken();
+    // }
+    // offConfirmUpdateTimer() {
+    //     this.ConfirmUpdateTimer = false;
+    // }
+    // resetCountdownState() {
+    //     // hentikan countdown lama
+    //     if (this.countdownTimer) {
+    //         clearInterval(this.countdownTimer);
+    //         this.countdownTimer = null;
+    //     }
+
+    //     // hentikan blinking
+    //     this.stopBlinking();
+    //     this.isWarning = false;
+    //     this.ConfirmUpdateTimer = false;
+    //     this.showNotification = false;
+    //     this.countdown = "";
+    // }
 
 
-    attached() {
-        this.updateTime();
-        this.timer = setInterval(() => { 
-            this.updateTime();
-        }, 1000);
-    }
+    // attached() {
+    //     this.updateTime();
+    //     this.timer = setInterval(() => { 
+    //         this.updateTime();
+    //     }, 1000);
+    // }
 
-    detached() {
-        clearInterval(this.timer);
-        if (this.countdownTimer) clearInterval(this.countdownTimer);
-    }
+    // detached() {
+    //     clearInterval(this.timer);
+    //     if (this.countdownTimer) clearInterval(this.countdownTimer);
+    // }
 
-    updateTime() {
-        const now = new Date();
-        this.timeFormatted = now.toLocaleTimeString("id-ID", {
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit"
-        });
-    }
+    // updateTime() {
+    //     const now = new Date();
+    //     this.timeFormatted = now.toLocaleTimeString("id-ID", {
+    //     hour: "2-digit",
+    //     minute: "2-digit",
+    //     second: "2-digit"
+    //     });
+    // }
 
-    startCountdown(expiredStr) {
-        if (this.countdownTimer) {
-            clearInterval(this.countdownTimer);
-            this.countdownTimer = null;
-        }
+    // startCountdown(expiredStr) {
+    //     if (this.countdownTimer) {
+    //         clearInterval(this.countdownTimer);
+    //         this.countdownTimer = null;
+    //     }
 
-        const parseLocalDateTime = (s) => {
-            if (!s) return null;
-            const clean = s.trim().replace('T', ' ');
-            const [dPart, tPart = '00:00:00'] = clean.split(' ');
-            const [yyyy, mm, dd] = dPart.split('-').map(x => parseInt(x, 10));
-            const [hh = 0, min = 0, sec = 0] = tPart.split(':').map(x => parseInt(x, 10));
-            return new Date(yyyy, mm - 1, dd, hh, min, sec);
-        };
+    //     const parseLocalDateTime = (s) => {
+    //         if (!s) return null;
+    //         const clean = s.trim().replace('T', ' ');
+    //         const [dPart, tPart = '00:00:00'] = clean.split(' ');
+    //         const [yyyy, mm, dd] = dPart.split('-').map(x => parseInt(x, 10));
+    //         const [hh = 0, min = 0, sec = 0] = tPart.split(':').map(x => parseInt(x, 10));
+    //         return new Date(yyyy, mm - 1, dd, hh, min, sec);
+    //     };
 
-        const expire = parseLocalDateTime(expiredStr);
-        if (!expire || isNaN(expire.getTime())) {
-            this.showNotification = false;
-            this.countdown = "";
-            return;
-        }
+    //     const expire = parseLocalDateTime(expiredStr);
+    //     if (!expire || isNaN(expire.getTime())) {
+    //         this.showNotification = false;
+    //         this.countdown = "";
+    //         return;
+    //     }
 
-        this.showNotification = true;
-        this.countdown = "";
+    //     this.showNotification = true;
+    //     this.countdown = "";
 
-        this.countdownTimer = setInterval(() => {
-            const now = new Date();
-            let diffMs = expire.getTime() - now.getTime();
-            if (diffMs < 0) diffMs = 0;
+    //     this.countdownTimer = setInterval(() => {
+    //         const now = new Date();
+    //         let diffMs = expire.getTime() - now.getTime();
+    //         if (diffMs < 0) diffMs = 0;
 
-            const remainingSeconds = Math.floor(diffMs / 1000);
+    //         const remainingSeconds = Math.floor(diffMs / 1000);
 
-            if (remainingSeconds <= 0) {
-            this.countdown = "...";
-            this.showNotification = true;
-            clearInterval(this.countdownTimer);
-            this.countdownTimer = null;
-            // this.updateDataLastTime();
-            this.logout();
-            this.ConfirmUpdateTimer = false;
-            return;
-            }
+    //         if (remainingSeconds <= 0) {
+    //         this.countdown = "...";
+    //         this.showNotification = true;
+    //         clearInterval(this.countdownTimer);
+    //         this.countdownTimer = null;
+    //         // this.updateDataLastTime();
+    //         this.logout();
+    //         this.ConfirmUpdateTimer = false;
+    //         return;
+    //         }
 
-            // // munculkan notif hanya saat <= 5 menit (300 detik)
-            // if (remainingSeconds <= 6 * 60) {
-            // this.showNotification = true;
-            // } else {
-            // this.showNotification = false;
-            // }
+    //         // // munculkan notif hanya saat <= 5 menit (300 detik)
+    //         // if (remainingSeconds <= 6 * 60) {
+    //         // this.showNotification = true;
+    //         // } else {
+    //         // this.showNotification = false;
+    //         // }
 
-            const hours = Math.floor(remainingSeconds / 3600);
-            const minutes = Math.floor((remainingSeconds % 3600) / 60);
-            const seconds = remainingSeconds % 60;
+    //         const hours = Math.floor(remainingSeconds / 3600);
+    //         const minutes = Math.floor((remainingSeconds % 3600) / 60);
+    //         const seconds = remainingSeconds % 60;
 
-            const hhStr = String(hours).padStart(2, '0');
-            const mmStr = String(minutes).padStart(2, '0');
-            const ssStr = String(seconds).padStart(2, '0');
+    //         const hhStr = String(hours).padStart(2, '0');
+    //         const mmStr = String(minutes).padStart(2, '0');
+    //         const ssStr = String(seconds).padStart(2, '0');
 
            
-            const wasWarning = this.isWarning;
-            this.isWarning = remainingSeconds <= 5 * 60;
+    //         const wasWarning = this.isWarning;
+    //         this.isWarning = remainingSeconds <= 5 * 60;
 
           
-            if (this.isWarning && !wasWarning) {
-                this.ConfirmUpdateTimer = true;
-                this.startBlinking();
-            }
-            if (!this.isWarning && wasWarning) {
-                this.stopBlinking();
-            }
-            this.countdown = `${hhStr}:${mmStr}:${ssStr}`;
+    //         if (this.isWarning && !wasWarning) {
+    //             this.ConfirmUpdateTimer = true;
+    //             this.startBlinking();
+    //         }
+    //         if (!this.isWarning && wasWarning) {
+    //             this.stopBlinking();
+    //         }
+    //         this.countdown = `${hhStr}:${mmStr}:${ssStr}`;
 
 
-        }, 1000);
-    }
+    //     }, 1000);
+    // }
 
-     startBlinking() {
-        if (this.blinkTimer) return;
-        this.isBlinkOn = true;
-        this.blinkTimer = setInterval(() => {
-            this.isBlinkOn = !this.isBlinkOn;
-        }, 500); // kedip setiap 500ms
-    }
+    //  startBlinking() {
+    //     if (this.blinkTimer) return;
+    //     this.isBlinkOn = true;
+    //     this.blinkTimer = setInterval(() => {
+    //         this.isBlinkOn = !this.isBlinkOn;
+    //     }, 500); // kedip setiap 500ms
+    // }
 
-    stopBlinking() {
-        if (this.blinkTimer) {
-            clearInterval(this.blinkTimer);
-            this.blinkTimer = null;
-        }
-        this.isBlinkOn = true;
-    }
+    // stopBlinking() {
+    //     if (this.blinkTimer) {
+    //         clearInterval(this.blinkTimer);
+    //         this.blinkTimer = null;
+    //     }
+    //     this.isBlinkOn = true;
+    // }
 
     logout() {
         this.authService.logout("#/login");

--- a/src/utils/password-validator.js
+++ b/src/utils/password-validator.js
@@ -8,8 +8,8 @@ export const PasswordValidator = {
       validationMessage += "Password harus diisi.\n";
     } else {
       // Validasi panjang minimal
-      if (password.length < 10) {
-        validationMessage += "Password minimal harus 10 karakter.\n";
+      if (password.length < 8) {
+        validationMessage += "Password minimal harus 8 karakter.\n";
       }
 
       // Validasi kompleksitas


### PR DESCRIPTION
Introduce an idle timeout/auto-logout flow and related warning popup in main.js, including setup/reset handlers and a visible countdown that logs out after expiry. Disable sidebar interactions while the ChangePass view is active and force logout/reload after a successful password change (changepass.js). Update login flow to import the password validator, validate on successful login, alert if password is weak and redirect to changepass (login.js). Relax minimum password length from 10 to 8 characters in utils/password-validator.js. Comment out the old confirmation overlay and countdown logic in nav-bar.html and nav-bar.js to avoid duplicate behavior. Also includes a small console.log in endpoint registration for debugging.