### PR TITLE
Handle session expiry and update last-login -Sprint 6

### DIFF
--- a/src/login.js
+++ b/src/login.js
@@ -1,10 +1,11 @@
 import { Aurelia, inject } from 'aurelia-framework';
 import { AuthService } from "aurelia-authentication";
+import { Config } from "aurelia-api";
 import '../styles/signin.css';
 import JSEncrypt from 'jsencrypt';
 import { PasswordValidator } from './utils/password-validator';
 
-@inject(AuthService)
+@inject(AuthService, Config)
 export class Login {
     // username = "dev";
     // password = "Standar123";
@@ -19,8 +20,9 @@ export class Login {
     error = false;
     disabledButton = false;
     
-    constructor(authService) {
+    constructor(authService, config) {
         this.authService = authService;
+        this.authEndpoint = config.getEndpoint('auth');
     }
 
     login() {
@@ -59,6 +61,12 @@ export class Login {
         return this.authService.login({ authEncrypted })
             .then(response => {
                 console.log("success logged " + response);
+
+                // Update last login dengan source 'login'
+                this.authEndpoint.update('me', null, { source: 'login' })
+                    .then(() => console.log('Last login updated (source: login)'))
+                    .catch(err => console.error('Error updating last login on sign in:', err));
+
                 this.statusMessage = PasswordValidator.validate(this.password);
                 
                 if (this.statusMessage) {

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,16 @@ let currentWarningEndAt = null;
 let idleEvents = ['mousemove', 'keydown', 'mousedown', 'touchstart', 'scroll'];
 let warningActive = false;
 
+/**
+ * Cek apakah expiredDateTime adalah DateTime.MinValue (0001-01-01T00:00:00).
+ * Jika ya, berarti session tidak memiliki batas waktu.
+ */
+function isDateTimeMinValue(dateStr) {
+    if (!dateStr) return false;
+    const d = new Date(dateStr);
+    return d.getFullYear() <= 1;
+}
+
 function enableIdleEvents() {
     if (!idleEventsActive) {
         idleEvents.forEach(event => {
@@ -47,8 +57,13 @@ function disableIdleEvents() {
     }
 }
 
-function updateLastLogin() {
-    return authEndpoint.update('me', null, {})
+/**
+ * Update last login ke server.
+ * @param {string} source - Asal request: 'popup' | 'im-here'
+ */
+function updateLastLogin(source) {
+    const body = source ? { source } : {};
+    return authEndpoint.update('me', null, body)
         .then(() => {
             return authService.getMe();
         })
@@ -71,7 +86,14 @@ function showWarningPopup() {
     warningActive = true;
 
     // Update last login dan ambil expiredDateTime untuk countdown
-    updateLastLogin().then((me) => {
+    updateLastLogin('popup').then((me) => {
+        // Jika expiredDateTime adalah DateTime.MinValue, session tidak dibatasi waktu
+        if (me && isDateTimeMinValue(me.expiredDateTime)) {
+            console.log('Session has no expiration (DateTime.MinValue). Skipping warning popup.');
+            warningActive = false;
+            return;
+        }
+
         let warningEndAt;
         if (me && me.expiredDateTime) {
             // Gunakan expiredDateTime dari server untuk countdown
@@ -111,6 +133,7 @@ function renderWarningPopup(warningEndAt, initialSecondsLeft) {
     `;
     document.body.appendChild(warningPopup);
     document.getElementById('idle-warning-btn').onclick = () => {
+        updateLastLogin('im-here'); // Kirim ke backend bahwa user masih aktif
         hideWarningPopup();   // harus duluan agar warningActive = false
         resetIdleTimer();     // baru set idle timer baru
     };
@@ -186,6 +209,7 @@ function onVisibilityChange() {
         authService.getMe()
             .then((result) => {
                 if (result && result.data && result.data.expiredDateTime) {
+                    if (isDateTimeMinValue(result.data.expiredDateTime)) return;
                     const expiredAt = new Date(result.data.expiredDateTime).getTime();
                     if (Date.now() >= expiredAt) {
                         forceLogout();
@@ -373,14 +397,19 @@ export async function configure(aurelia) {
         try {
             const result = await authService.getMe();
             if (result && result.data && result.data.expiredDateTime) {
-                const expiredAt = new Date(result.data.expiredDateTime).getTime();
-                if (Date.now() >= expiredAt) {
-                    await authService.logout();
-                    window.location.href = '#/login';
-                    aurelia.setRoot('login');
-                    return;
+                if (!isDateTimeMinValue(result.data.expiredDateTime)) {
+                    const expiredAt = new Date(result.data.expiredDateTime).getTime();
+                    if (Date.now() >= expiredAt) {
+                        await authService.logout();
+                        window.location.href = '#/login';
+                        aurelia.setRoot('login');
+                        return;
+                    }
                 }
             }
+
+            // Update last login saat reload halaman
+            await updateLastLogin('reload');
         } catch (error) {
             console.error('Error checking session on page load:', error);
             // Jika gagal cek, arahkan ke login untuk keamanan


### PR DESCRIPTION
Inject Config into Login and use auth API endpoint to record last-login on sign in (sends { source: 'login' }).

Introduce isDateTimeMinValue helper to treat DateTime.MinValue (0001-01-01T00:00:00) as "no expiration" and skip timeout/warning/logout logic for such sessions. Refactor updateLastLogin to accept a source param and include that in the request body, and call it from the idle warning popup ('popup' and 'im-here') and on app configure ('reload').

Overall this prevents showing idle warnings or forcing logout for sessions without expiry and ensures the backend receives activity pings with their origin.