### PR TITLE
Add DO create date filters and export - SPRINT 6

### DIFF
--- a/src/modules/garment-purchasing/monitoring-delivery-order-all/list.html
+++ b/src/modules/garment-purchasing/monitoring-delivery-order-all/list.html
@@ -33,6 +33,11 @@
 
         <au-datepicker value.bind="dateTo" label="Sampai Tgl" options.bind="controlOptions" error.bind="error.date">
         </au-datepicker>
+        <au-datepicker value.bind="createDateFrom" label="Dari Tgl Pembuatan DO" options.bind="controlOptions" error.bind="error.date">
+        </au-datepicker>
+
+        <au-datepicker value.bind="createDateTo" label="Sampai Tgl" options.bind="controlOptions" error.bind="error.date">
+        </au-datepicker>
 
         <!-- <datepicker label="Tanggal Awal" value.bind="dateFrom" change.delegate="dateFromChanged($event)"></datepicker>
         <datepicker label="Tanggal Akhir" value.bind="dateTo" min.bind="dateFrom"></datepicker> -->

--- a/src/modules/garment-purchasing/monitoring-delivery-order-all/list.js
+++ b/src/modules/garment-purchasing/monitoring-delivery-order-all/list.js
@@ -139,6 +139,12 @@ export class List {
         { field: "TermPayment", title: "Term Pembayaran", sortable: false },
         { field: "diffArrival", title: "Selisih Kedatangan dengan PO", sortable: false },
         { field: "surplus", title: "% Kelebihan Kedatangan", sortable: false },
+
+        {
+            field: "CreateDateDO", title: "Tanggal Pembuatan Surat Jalan", sortable: false, formatter: function (value, data, index) {
+                return moment(value).format("DD MMM YYYY");
+            }
+        },
     ];
 
     search() {
@@ -192,6 +198,8 @@ export class List {
             paymentbill: this.paymentbill ? this.paymentbill : "",
             dateTo: this.dateTo ? moment(this.dateTo).format("MM/DD/YYYY") : "",
             dateFrom: this.dateFrom ? moment(this.dateFrom).format("MM/DD/YYYY") : "",
+            createDateTo: this.createDateTo ? moment(this.createDateTo).format("MM/DD/YYYY") : "",
+            createDateFrom: this.createDateFrom ? moment(this.createDateFrom).format("MM/DD/YYYY") : "",
         };
         return this.flag ?
             (
@@ -238,6 +246,8 @@ export class List {
                 paymentbill: this.paymentbill ? this.paymentbill : "",
                 dateTo: this.dateTo ? moment(this.dateTo).format("MM/DD/YYYY") : "",
                 dateFrom: this.dateFrom ? moment(this.dateFrom).format("MM/DD/YYYY") : "",
+                createDateTo: this.createDateTo ? moment(this.createDateTo).format("MM/DD/YYYY") : "",
+                createDateFrom: this.createDateFrom ? moment(this.createDateFrom).format("MM/DD/YYYY") : "",
 
             };
             // Check if Type is Report or Monitoring

--- a/src/modules/garment-purchasing/monitoring-delivery-order-all/service.js
+++ b/src/modules/garment-purchasing/monitoring-delivery-order-all/service.js
@@ -23,7 +23,7 @@ export class Service extends RestService {
     }
 
     getXls(info) {
-        var endpoint = `${serviceUri}/download?no=${info.no}&poEksNo=${info.poEksNo}&supplierId=${info.supplierId}&billno=${info.billno}&paymentbill=${info.paymentbill}&dateFrom=${info.dateFrom}&dateTo=${info.dateTo}`;
+        var endpoint = `${serviceUri}/download?no=${info.no}&poEksNo=${info.poEksNo}&supplierId=${info.supplierId}&billno=${info.billno}&paymentbill=${info.paymentbill}&dateFrom=${info.dateFrom}&dateTo=${info.dateTo}&createDateFrom=${info.createDateFrom}&createDateTo=${info.createDateTo}`;
         return super.getXls(endpoint);
     }
 }
@@ -46,7 +46,7 @@ export class PurchasingService extends RestService {
     }
 
     getXls(info) {
-        var endpoint = `${deliveryOrderServiceUri}/monitoring/download?no=${info.no}&poEksNo=${info.poEksNo}&supplierId=${info.supplierId}&billno=${info.billno}&paymentbill=${info.paymentbill}&dateFrom=${info.dateFrom}&dateTo=${info.dateTo}`;
+        var endpoint = `${deliveryOrderServiceUri}/monitoring/download?no=${info.no}&poEksNo=${info.poEksNo}&supplierId=${info.supplierId}&billno=${info.billno}&paymentbill=${info.paymentbill}&dateFrom=${info.dateFrom}&dateTo=${info.dateTo}&createDateFrom=${info.createDateFrom}&createDateTo=${info.createDateTo}`;
         return super.getXls(endpoint);
     }
 


### PR DESCRIPTION
Add filtering and export support for Delivery Order creation dates. Changes include: added two datepickers (createDateFrom/createDateTo) in list.html; added a "Tanggal Pembuatan Surat Jalan" column with formatted dates in list.js; included createDateFrom/createDateTo in the search payloads; and appended these params to the XLS download endpoints in service.js. Also switch purchasingAzure to a local dev URL in main.js (original Azure URL commented out) for local testing.