### PR TITLE
Add supplier loader option to debit note -SPPRINT 6

### DIFF
--- a/src/modules/garment-shipping/debit-note/create.js
+++ b/src/modules/garment-shipping/debit-note/create.js
@@ -27,6 +27,19 @@ export class Create {
     }
 
     saveCallback(event) {
+        // Pastikan payload selalu format buyer
+         this.data.loaderType = this.data.selectedLoader;
+        console.log(this.data);
+        if (this.data.selectedLoader === "supplier" && this.data.supplier) {
+            this.data.buyer = {
+                Id: this.data.supplier.Id,
+                Code: this.data.supplier.code,
+                Name: this.data.supplier.name
+            };
+            //this.data.buyer = this.data.supplier;
+            delete this.data.supplier;
+        }
+       
         this.service.create(this.data)
             .then(result => {
                 alert("Data berhasil dibuat");

--- a/src/modules/garment-shipping/debit-note/data-form.html
+++ b/src/modules/garment-shipping/debit-note/data-form.html
@@ -12,10 +12,19 @@
                     options.bind="controlOptions">
                 </au-datepicker>
 
-                <au-autocomplete label="Buyer" placeholder="Pilih Buyer" value.bind="data.buyer"
+                <radiobutton label="Pilih Loader" value.bind="selectedLoader" error.bind="error.selectedLoader" selections.bind="loaderSelections" read-only.bind="readOnly" options.bind="controlOptions"></radiobutton>
+
+
+                <au-autocomplete if.bind="selectedLoader === 'buyer'" label="Buyer" placeholder="Pilih Buyer" value.bind="data.buyer"
                     error.bind="error.buyer" loader.bind="buyerLoader" text.bind="buyerView"
                     read-only.bind="readOnly" options.bind="controlOptions">
                 </au-autocomplete>
+
+                <au-autocomplete if.bind="selectedLoader === 'supplier'" label="Supplier" value.bind="data.supplier"
+                    placeholder="Pilih Supplier" loader.bind="supplierLoader" text.bind="supplierView"
+                    read-only.bind="readOnly" options.bind="controlOptions">
+                </au-autocomplete>
+                
 
                 <au-numeric label="Amount" value.to-view="totalAmount" error.bind="error.amount" read-only="true"
                     options.bind="controlOptions">

--- a/src/modules/garment-shipping/debit-note/data-form.js
+++ b/src/modules/garment-shipping/debit-note/data-form.js
@@ -3,17 +3,36 @@ import { Service } from "./service";
 
 const BuyerLoader = require('../../../loader/garment-buyers-loader');
 const AccountBankLoader = require('../../../loader/account-banks-loader');
-
+const SupplierLoader = require("../../../loader/garment-supplier-loader");
 @inject(Service)
 export class DataForm {
 
     @bindable readOnly = false;
     @bindable isEdit = false;
     @bindable title;
+    @bindable isView = false;
+    @bindable selectedLoader = "buyer";
+    selectedLoaderChanged(newValue, oldValue) {
+        console.log(this.readOnly);
+        if (!this.readOnly && !this.isEdit) {
+            if (newValue === "buyer") {
+                this.data.supplier = null;
+                this.data.buyer = null;
+            } else if (newValue === "supplier") {
+                this.data.buyer = null;
+                this.data.supplier = null;
+            }
+        }
+        this.data.selectedLoader = newValue;
+    }
+    loaderSelections = [
+        { value: "buyer", label: "Buyer" },
+        { value: "supplier", label: "Supplier" }
+    ];
 
     controlOptions = {
         label: {
-            length: 3
+            length: 4
         },
         control: {
             length: 5
@@ -41,13 +60,19 @@ export class DataForm {
     get bankLoader() {
         return AccountBankLoader;
     }
-
+    get supplierLoader() {
+        return SupplierLoader;
+    }
     buyerView = (data) => {
         return `${data.Code || data.code} - ${data.Name || data.name}`;
     }
 
     bankView = (data) => {
         return `${data.BankName || data.bankName} - ${data.Currency ? data.Currency.Code : data.currency.code } - ${data.AccountNumber || data.accountNumber}`;
+    }
+
+    supplierView = (data) => {
+        return `${data.Code || data.code} - ${data.Name || data.name}`;
     }
 
     get bankQuery(){
@@ -59,6 +84,14 @@ export class DataForm {
         this.context = context;
         this.data = context.data;
         this.error = context.error;
+
+        if(this.data.loaderType === "supplier"){
+            this.data.supplier = this.data.buyer;
+        }
+        this.selectedLoader = this.data.loaderType ? this.data.loaderType : "buyer";
+
+        
+        console.log(this.data);
     }
 
     get totalAmount() {

--- a/src/modules/garment-shipping/debit-note/edit.js
+++ b/src/modules/garment-shipping/debit-note/edit.js
@@ -26,6 +26,11 @@ export class Edit {
     }
 
     saveCallback(event) {
+        // Pastikan payload selalu format buyer
+        if (this.data.selectedLoader === "supplier" && this.data.supplier) {
+            this.data.buyer = this.data.supplier;
+            delete this.data.supplier;
+        }
         this.service.update(this.data)
             .then(result => {
                 const encoded = Base64Helper.encode(this.data.id);

--- a/src/modules/garment-shipping/debit-note/style/radiobutton-align.css
+++ b/src/modules/garment-shipping/debit-note/style/radiobutton-align.css
@@ -1,0 +1,12 @@
+.radiobutton-inline-label {
+  display: flex;
+  align-items: center;
+}
+.radiobutton-inline-label label {
+  margin-bottom: 0;
+  margin-right: 10px;
+  min-width: 120px;
+}
+.radiobutton-inline-label .radio-inline {
+  margin-right: 150px;
+}

--- a/src/modules/garment-shipping/debit-note/view.js
+++ b/src/modules/garment-shipping/debit-note/view.js
@@ -5,7 +5,7 @@ import { Base64Helper } from '../../../utils/base-64-coded-helper';
 
 @inject(Router, Service)
 export class View {
-
+    isView = true;
     constructor(router, service) {
         this.router = router;
         this.service = service;


### PR DESCRIPTION
Allow choosing between Buyer and Supplier as the loader in the garment-shipping debit note form. Added a radio button selection and supplier autocomplete, supplier loader and supplier view formatter, and UI alignment CSS. The form initializes selectedLoader from data.loaderType and clears the opposite field when switching. On create and edit, supplier payloads are mapped into the expected buyer field (and supplier removed) so backend always receives a buyer-format payload. Also set isView in view.js and adjusted control label length in form controls.