### PR TITLE
Disable auto-setting of data.unit based on OrderNo - SPRINT 7

### DIFF
--- a/src/modules/packing-sku-inventory/dyeing-printing-out-packaging/template/item.js
+++ b/src/modules/packing-sku-inventory/dyeing-printing-out-packaging/template/item.js
@@ -90,11 +90,11 @@ export class CartItem {
                 }
             }
 
-            if (this.selectedProductionOrder.OrderNo.charAt(0) === 'P') {
-                this.data.unit = "PRINTING"
-            } else {
-                this.data.unit = "DYEING"
-            }
+            // if (this.selectedProductionOrder.OrderNo.charAt(0) === 'P') {
+            //     this.data.unit = "PRINTING"
+            // } else {
+            //     this.data.unit = "DYEING"
+            // }
 
         }
     }


### PR DESCRIPTION
Commented out the conditional that assigned this.data.unit to "PRINTING" or "DYEING" based on the first character of selectedProductionOrder.OrderNo. This disables the automatic unit assignment, likely to prevent incorrect defaults or to allow replacement with alternative unit logic.