### PR TITLE
Add IsTolerance checkbox and controlOptions - Sprint 8

### DIFF
--- a/src/modules/sales/production-order/data-form.html
+++ b/src/modules/sales/production-order/data-form.html
@@ -168,6 +168,14 @@
             error.bind="error.ShippingQuantityTolerance" read-only.bind="readOnly" post-fix="%" if.bind="nameCheck">
           </numeric>
 
+          <au-checkbox
+          label="Toleransi Minus?"
+          value.bind="data.IsTolerance"
+          read-only.bind="readOnly"
+          options.bind="controlOptions"
+          if.bind="nameCheck">
+          </au-checkbox>
+
           <textbox label="Asal Material" value.bind="data.MaterialOrigin" error.bind="error.MaterialOrigin"
             read-only.bind="(readOnly)"></textbox>
 

--- a/src/modules/sales/production-order/data-form.js
+++ b/src/modules/sales/production-order/data-form.js
@@ -44,6 +44,15 @@ export class DataForm {
   rq = false;
 
   UOMOptions = ["MTR", "PCS"];
+   controlOptions = {
+    label: {
+      length: 4
+    },
+    control: {
+      length: 7,
+      align: "right"
+    }
+  }
 
 
   constructor(bindingEngine, element, service) {


### PR DESCRIPTION
Introduce an 'Toleransi Minus?' au-checkbox in the production-order form bound to data.IsTolerance (respecting readOnly and nameCheck). Add controlOptions in the form ViewModel to configure label/control lengths and alignment used by the new checkbox.