### PR TITLE
Refine external expenditure delete logic- Sprint 9

### DIFF
--- a/src/modules/garment-purchasing/unit-expenditure-note-by-user/view.js
+++ b/src/modules/garment-purchasing/unit-expenditure-note-by-user/view.js
@@ -60,8 +60,24 @@ export class View {
       }
     }
     if (this.data.ExpenditureType === "EXTERNAL") {
-      if (this.data.ExpenditureTo != "PENJUALAN") {
-        this.hasDelete = false;
+      // if (this.data.ExpenditureTo != "PENJUALAN") {
+      //   this.hasDelete = false;
+      // }
+      console.log(this.data.DOQuantity);
+          console.log(this.data.IsDeletedCount);
+      if (this.data.ExpenditureTo == "PENJUALAN") {
+        this.hasDelete = true;
+      }else if (this.data.ExpenditureTo == "PEMBELIAN")
+      {
+        if(this.data.IsDeletedCount > 0 ){
+          this.hasDelete = false;
+        }else if (this.data.IsDeletedCount == 0 && this.data.DOQuantity > 0){
+
+          
+          this.hasDelete = false;
+        }else{
+          this.hasDelete = true;
+        }
       }
       this.hasEdit = false;
     }


### PR DESCRIPTION
Replace the previous blanket disabling of delete for EXTERNAL expenditures with finer-grained rules: enable delete for PENJUALAN, and for PEMBELIAN determine hasDelete based on IsDeletedCount and DOQuantity. Added temporary console.log statements and left the old check commented out.