### PR TITLE
Add Approval Souching/MD

### DIFF
--- a/src/modules/garment-purchasing/purchase-order-external-approval/list.js
+++ b/src/modules/garment-purchasing/purchase-order-external-approval/list.js
@@ -62,6 +62,34 @@ export class List {
         //         }
         //     });
 
+            if (this.type === "manager") {
+                return this.service.searchManager(arg)
+                .then(result => {
+                    for (var _data of result.data) {
+                        var prNo = _data.Items.map(function (item) {
+                            return `<li>${item.PRNo}</li>`;
+                        });
+                        prNo = prNo.filter(function (elem, index, self) {
+                            return index == self.indexOf(elem);
+                        })
+                        _data.purchaseRequestNo = `<ul>${prNo.join()}</ul>`;
+                        if (_data.IsOverBudget) {
+                            if (_data.IsApprovedAnggaran) {
+                                _data.approveStatus = "SUDAH";
+                            } else {
+                                _data.approveStatus = "BELUM";
+                            }
+                        } else {
+                            _data.approveStatus = "-";
+                        }
+                    }
+                    return {
+                        total: result.info.total,
+                        data: result.data
+                    }
+                });
+            }
+
             return this.service.search(arg)
             .then(result => {
                 for (var _data of result.data) {
@@ -113,11 +141,18 @@ export class List {
         }
 
         switch (type) {
-            case "manager":
+            case "other":
                 this.filter = {
                     IsPosted: true,
-                    IsApprovedManager: false,
+                    ApproveOther: true,
+                    IsApprovedOther: false,
                     IsOverBudget: true,
+                    ApprovedOtherBy: username
+                };
+                break;
+            case "manager":
+                this.filter = {
+                    IsApprovedManager: false,
                     ApprovedManagerBy: username
                 };
                 break;

--- a/src/modules/garment-purchasing/purchase-order-external-approval/service.js
+++ b/src/modules/garment-purchasing/purchase-order-external-approval/service.js
@@ -14,6 +14,11 @@ class Service extends RestService {
         return super.list(endpoint, info);
     }
 
+     searchManager(info) {
+        var endpoint = `${serviceUri}/manager`;
+        return super.list(endpoint, info);
+    }
+
     getById(id) {
         var endpoint = `${serviceUri}/${id}`;
         return super.get(endpoint);

--- a/src/modules/garment-purchasing/purchase-order-external-approval/view.html
+++ b/src/modules/garment-purchasing/purchase-order-external-approval/view.html
@@ -132,7 +132,19 @@
                 <au-multiline label="Keterangan" value.bind="data.Remark" placeholder="tambah keterangan"
                     read-only.bind="readOnly" options.bind="controlOptions">
                 </au-multiline>
+
+                <au-checkbox label="Approve MG Sourcing/MD?" value.bind="data.ApproveOther" 
+                    read-only.bind="readOnly" options.bind="controlOptions">
+                </au-checkbox>
                 
+                <au-textbox 
+                    label="MG Sourcing/MD Approval"
+                    value.bind="data.ApprovedOtherBy" 
+                    read-only.bind="true"
+                    if.bind="data.ApproveOther"
+                    options.bind="controlOptions">
+                </au-textbox>
+
                 <au-textbox 
                     label="Manager Approval"
                     value.bind="data.ApprovedManagerBy" 

--- a/src/modules/garment-purchasing/purchase-order-external-approval/view.js
+++ b/src/modules/garment-purchasing/purchase-order-external-approval/view.js
@@ -81,6 +81,9 @@ export class View {
         const type = parentInstruction.config.settings.type;
 
         switch (type) {
+            case "other":
+                this.type = "Other";
+                break;
             case "manager":
                 this.type = "Manager";
                 break;

--- a/src/modules/garment-purchasing/purchase-order-external-kasie/data-form.html
+++ b/src/modules/garment-purchasing/purchase-order-external-kasie/data-form.html
@@ -238,6 +238,18 @@
                     options.bind="controlOptions">
                 </au-multiline>
 
+                <au-checkbox label="Approve MG Sourcing/MD?" value.bind="data.ApproveOther" 
+                    read-only.bind="readOnly" options.bind="controlOptions">
+                </au-checkbox>
+                
+                <au-textbox 
+                    label="MG Sourcing/MD Approval"
+                    value.bind="data.ApprovedOtherBy" 
+                    read-only.bind="true"
+                    if.bind="data.ApproveOther"
+                    options.bind="controlOptions">
+                </au-textbox>
+
                 <au-autocomplete 
                     label="Manager Approval"
                     value.bind="IsApprovedManager" 

--- a/src/modules/garment-purchasing/purchase-order-external-kasie/list.js
+++ b/src/modules/garment-purchasing/purchase-order-external-kasie/list.js
@@ -51,6 +51,7 @@ export class List {
                 return value ? "YA" : "TIDAK";
             }
         },
+        { field: "IsApprovedOtherLabel", title: "Approval Other" },
         { field: "IsApprovedManagerLabel", title: "Approval Manager" },
         { field: "IsApprovedGMManagerLabel", title: "Approval GM" },
         { field: "IsApprovedAnggaranLabel", title: "Approval Anggaran" },
@@ -82,6 +83,7 @@ export class List {
                     _data.IsApprovedManagerLabel = _data.IsOverBudget ? (_data.IsApprovedManager ? "SUDAH" : "BELUM") : "-";
                     _data.IsApprovedGMManagerLabel = _data.IsOverBudget ? (_data.IsApprovedGeneralManager ? "SUDAH" : "BELUM") : "-";
                     _data.IsApprovedAnggaranLabel = _data.IsOverBudget ? (_data.IsApprovedAnggaran ? "SUDAH" : "BELUM") : "-";
+                    _data.IsApprovedOtherLabel = _data.ApproveOther ? (_data.IsApprovedOther ? "SUDAH" : "BELUM") : "-";
                 
                 }
                 return {

--- a/src/modules/garment-purchasing/purchase-order-external/data-form.html
+++ b/src/modules/garment-purchasing/purchase-order-external/data-form.html
@@ -139,6 +139,21 @@
                 <au-multiline label="Keterangan" value.bind="data.Remark" placeholder="tambah keterangan"
                     read-only.bind="readOnly" options.bind="controlOptions">
                 </au-multiline>
+                <au-checkbox label="Approve MG Sourcing/MD?" value.bind="data.ApproveOther" 
+                    read-only.bind="readOnly" if.bind="showManagerApproval" change.delegate="approveOtherChanged($event)" options.bind="controlOptions">
+                </au-checkbox>
+                <au-autocomplete 
+                    label="MG Sourcing/MD Approval"
+                    value.bind="IsApprovedOther" 
+                    error.bind="error.ApprovedOtherBy"
+                    loader.bind="accountSignatureLoader2"
+                    placeholder="Cari Approval" 
+                    text.bind="ApprovedOtherView"
+                    key="Id"
+                    read-only.bind="readOnly"
+                    if.bind="data.ApproveOther"
+                    options.bind="controlOptions">
+                </au-autocomplete>
                 <au-autocomplete 
                     label="Manager Approval"
                     value.bind="IsApprovedManager" 

--- a/src/modules/garment-purchasing/purchase-order-external/data-form.js
+++ b/src/modules/garment-purchasing/purchase-order-external/data-form.js
@@ -24,6 +24,7 @@ export class DataForm {
     keywords = ''
     @bindable kurs = {};
     @bindable IsApprovedManager;
+    @bindable IsApprovedOther;
     @bindable hasOverBudgetItems = false;
 
     termPaymentImportOptions = ['T/T PAYMENT', 'CMT', 'FREE FROM BUYER', 'SAMPLE'];
@@ -126,6 +127,10 @@ export class DataForm {
             UserName: this.data.ApprovedManagerBy || ""
         };
 
+        this.IsApprovedOther ={
+            UserName: this.data.ApprovedOtherBy || ""
+        };
+
         if (this.data.Id || this.ISEDIT) {
             this.updateOverBudgetStatus();
         } else if (this.data.Items && this.data.Items.length > 0 && this.options.checkOverBudget) {
@@ -170,6 +175,8 @@ export class DataForm {
         if (previousOverBudgetStatus === true && this.hasOverBudgetItems === false) {
         this.IsApprovedManager = null;
         this.data.ApprovedManagerBy = "";
+        this.IsApprovedOther = null;
+        this.data.ApprovedOtherBy = "";
     }
     }
 
@@ -682,18 +689,18 @@ export class DataForm {
         }
     }
 
-    // get accountSignatureLoader1() {
-    //     return (keyword) => accountSignatureLoader(keyword, { Position: ["Manager Purchasing", "Manager Merchandiser"] }); //Username ganti dengan jabatan atau posisi dari Account Signature yang diinginkan
-    // }
+    get accountSignatureLoader1() {
+        return (keyword) => accountSignatureLoader(keyword, { Position: "Manager Purchasing" }); //Username ganti dengan jabatan atau posisi dari Account Signature yang diinginkan
+    }
 
-  get accountSignatureLoader1() {
-    return async (keyword) => {
-        const res1 = await accountSignatureLoader(keyword, { Position: "Manager Purchasing" });
-        const res2 = await accountSignatureLoader(keyword, { Position: "Manager Merchandiser" });
+//   get accountSignatureLoader1() {
+//     return async (keyword) => {
+//         const res1 = await accountSignatureLoader(keyword, { Position: "Manager Purchasing" });
+//         const res2 = await accountSignatureLoader(keyword, { Position: "Manager Merchandiser" });
 
-        return [...res1, ...res2];
-    };
-}
+//         return [...res1, ...res2];
+//     };
+// }
 
     ApprovedManagerView = (unit) => {
         return `${unit.UserName}`;
@@ -709,6 +716,41 @@ export class DataForm {
         }
     }
         
+
+       get accountSignatureLoader2() {
+    return async (keyword) => {
+        const res1 = await accountSignatureLoader(keyword, { Position: "Manager Sourcing" });
+        const res2 = await accountSignatureLoader(keyword, { Position: "Manager Merchandiser" });
+
+        return [...res1, ...res2];
+    };
+}
+
+    ApprovedOtherView = (unit) => {
+        return `${unit.UserName}`;
+    }
+    
+    IsApprovedOtherChanged(newValue) {
+        this.IsApprovedOther = newValue;
+        if (this.IsApprovedOther){
+        this.data.ApprovedOtherBy = this.IsApprovedOther.UserName;
+        this.data.ApprovedOtherPosition = this.IsApprovedOther.Position;
+        }else{
+        this.data.ApprovedOtherBy = "";
+        this.data.ApprovedOtherPosition = "";
+        this.IsApprovedOther = null;
+        }
+    }
+
+    approveOtherChanged(e) {
+        var isChecked = e.srcElement.checked || false;
+        if (!isChecked) {
+            this.IsApprovedOther = null;
+            this.data.ApprovedOtherBy = "";
+            this.data.ApprovedOtherPosition = "";
+            if (this.error) this.error.ApprovedOtherBy = "";
+        }
+    }
 
     onItemChangeDelegate(event) {
         this.onitemchange(event); 

--- a/src/modules/garment-purchasing/purchase-order-external/list.js
+++ b/src/modules/garment-purchasing/purchase-order-external/list.js
@@ -54,6 +54,7 @@ export class List {
                 return value ? "YA" : "TIDAK";
             }
         },
+        { field: "IsApprovedOtherLabel", title: "Approval Other" },
         { field: "IsApprovedManagerLabel", title: "Approval Manager" },
         { field: "IsApprovedGMManagerLabel", title: "Approval GM" },
         { field: "IsApprovedAnggaranLabel", title: "Approval Anggaran" },
@@ -85,6 +86,7 @@ export class List {
                     _data.IsApprovedManagerLabel = _data.IsOverBudget ? (_data.IsApprovedManager ? "SUDAH" : "BELUM") : "-";
                     _data.IsApprovedGMManagerLabel = _data.IsOverBudget ? (_data.IsApprovedGeneralManager ? "SUDAH" : "BELUM") : "-";
                     _data.IsApprovedAnggaranLabel = _data.IsOverBudget ? (_data.IsApprovedAnggaran ? "SUDAH" : "BELUM") : "-";
+                    _data.IsApprovedOtherLabel = _data.ApproveOther ? (_data.IsApprovedOther ? "SUDAH" : "BELUM") : "-";
                 }
                 return {
                     total: result.info.total,

--- a/src/routes/garment-purchasing.js
+++ b/src/routes/garment-purchasing.js
@@ -1478,7 +1478,22 @@ module.exports = [
       iconClass: "fa fa-dashboard",
     },
   },
-
+  {
+        route: '/garment/purchase-order-external-approval/other',
+        name: 'purchase-order-external-approval-other',
+        moduleId: './modules/garment-purchasing/purchase-order-external-approval/index',
+        nav: true,
+        title: 'Purchase Order External Approval',
+        auth: true,
+        settings: {
+            group: "g-purchasing",
+            subGroup: "approval",
+            // permission: { "PGA": 1, "C7": 1, "C9": 1 },
+            permission: { H84 : 1 },
+            iconClass: 'fa fa-calculator',
+            type: "other"
+        }
+    },
   {
         route: '/garment/purchase-order-external-approval/manager',
         name: 'purchase-order-external-approval-manager',


### PR DESCRIPTION
Introduce a new "other" approval flow for MG Sourcing/MD: add route /purchase-order-external-approval/other and service.searchManager endpoint. Update approval lists and views to show ApproveOther/IsApprovedOther and an ApprovedOtherBy field (checkbox, textbox/autocomplete) across data-form, kasie, and view files; add corresponding list columns and label logic. Adjust List/service logic to fetch manager-specific results and set filters for the new type, deduplicate PR numbers in manager search results, and add accountSignatureLoader2 + handlers for selecting MG Sourcing/MD signers. Also refine accountSignatureLoader1 to only Manager Purchasing and comment out the previous merged-loader implementation.