### PR TITLE
Remove IsDeletedCount>0 deletion guard - SPRINT 9

### DIFF
--- a/src/modules/garment-purchasing/unit-expenditure-note-by-user/view.js
+++ b/src/modules/garment-purchasing/unit-expenditure-note-by-user/view.js
@@ -69,9 +69,11 @@ export class View {
         this.hasDelete = true;
       }else if (this.data.ExpenditureTo == "PEMBELIAN")
       {
-        if(this.data.IsDeletedCount > 0 ){
-          this.hasDelete = false;
-        }else if (this.data.IsDeletedCount == 0 && this.data.DOQuantity > 0){
+        // if(this.data.IsDeletedCount > 0 ){
+        //   this.hasDelete = false;
+        // }else 
+          
+          if (this.data.IsDeletedCount == 0 && this.data.DOQuantity > 0){
 
           
           this.hasDelete = false;


### PR DESCRIPTION
Commented out the branch that prevented deletion when data.IsDeletedCount > 0. Now hasDelete is only set to false when IsDeletedCount == 0 and DOQuantity > 0, changing the conditions that disable the delete action.