### PR TITLE
Support partial numbers for production orders - SPRINT 9

### DIFF
--- a/src/modules/production/finishing-printing/dyestuff-chemical-usage-receipt/data-form.html
+++ b/src/modules/production/finishing-printing/dyestuff-chemical-usage-receipt/data-form.html
@@ -72,7 +72,9 @@
                     read-only.bind="readOnly || isEdit" error.bind="error.ProductionOrder"
                     options.bind="controlOptions">
                 </au-autocomplete>
-
+                <au-textbox label=" " value.bind="textPartial" read-only.bind="true" if.bind="partialNumber > 0" 
+                    options.bind="controlOptions">
+                </au-textbox>
                 <au-numeric label="Jumlah Order" format="0.00" value.bind="data.ProductionOrder.OrderQuantity"
                     read-only.bind="true" options.bind="controlOptions">
                 </au-numeric>
@@ -191,7 +193,7 @@
                                 Adjs 3
                             </th>
                             <th width="20%">
-                                Adjs 4 aa
+                                Adjs 4
                             </th>
                             <th width="20%">
                                 Adjs 5

--- a/src/modules/production/finishing-printing/dyestuff-chemical-usage-receipt/data-form.js
+++ b/src/modules/production/finishing-printing/dyestuff-chemical-usage-receipt/data-form.js
@@ -7,6 +7,7 @@ var moment = require('moment');
 
 @inject(Service)
 export class DataForm {
+    partialNumber = 0;
     @bindable title;
     @bindable readOnly;
 
@@ -81,12 +82,25 @@ export class DataForm {
 
     construction = "";
     @bindable selectedProductionOrder;
-    selectedProductionOrderChanged(n, o) {
+    async selectedProductionOrderChanged(n, o) {
         if (this.selectedProductionOrder) {
             this.data.ProductionOrder = this.selectedProductionOrder;
-
-            this.construction = `${this.selectedProductionOrder.Material.Name} / ${this.selectedProductionOrder.MaterialConstruction.Name} / ${this.selectedProductionOrder.MaterialWidth}`
+            this.construction = `${this.selectedProductionOrder.Material.Name} / ${this.selectedProductionOrder.MaterialConstruction.Name} / ${this.selectedProductionOrder.MaterialWidth}`;
+            // Ambil partial number
+            try {
+                const result = await this.service.getPartial(this.data.ProductionOrder.Id);
+                this.partialNumber = result && result.Data ? result.Data : 0;
+            } catch (e) {
+                this.partialNumber = 0;
+            }
+        } else {
+            this.partialNumber = 0;
         }
+        this.partialNumber = this.isEdit ? this.data.NumberOfPartial : this.partialNumber;
+        console.log(this.isEdit);
+        this.textPartial = this.partialNumber > 0 ? `Partial ${this.partialNumber}` : "";
+        this.data.NumberOfPartial = this.partialNumber;
+
     }
     @bindable selectedStrikeOff;
     async selectedStrikeOffChanged(n, o) {

--- a/src/modules/production/finishing-printing/dyestuff-chemical-usage-receipt/list.js
+++ b/src/modules/production/finishing-printing/dyestuff-chemical-usage-receipt/list.js
@@ -8,7 +8,17 @@ export class List {
     context = ["Detail", "Cetak PDF"];
     itemYears = [];
     columns = [
-        { field: "ProductionOrder.OrderNo", title: "No SPP" },
+        {
+            field: "ProductionOrder.OrderNo",
+            title: "No SPP",
+            formatter: function(value, data, index) {
+                // Cek property NumberOfPartial pada data
+                if (data.NumberOfPartial && data.NumberOfPartial > 0) {
+                    return `${value} - Partial ${data.NumberOfPartial}`;
+                }
+                return value;
+            }
+        },
         { field: "StrikeOff.Code", title: "Motif" }
     ];
     loader = (info) => {

--- a/src/modules/production/finishing-printing/dyestuff-chemical-usage-receipt/service.js
+++ b/src/modules/production/finishing-printing/dyestuff-chemical-usage-receipt/service.js
@@ -45,4 +45,9 @@ export class Service extends RestService {
     return super.get(endpoint);
   }
 
+  getPartial(productionOrderId) {
+    let endpoint = `${serviceUri}/get-partial/${productionOrderId}`;
+    return super.get(endpoint);
+  }
+
 }

--- a/src/modules/production/finishing-printing/dyestuff-chemical-usage-receipt/view.js
+++ b/src/modules/production/finishing-printing/dyestuff-chemical-usage-receipt/view.js
@@ -14,6 +14,9 @@ export class View {
     async activate(params) {
         let id = params.id;
         this.data = await this.service.getById(id);
+        console.log(this.data.NumberOfPartial);
+        
+
     }
 
     list() {


### PR DESCRIPTION
Add handling for partial production orders: fetch partial number from API and surface it in the form and list. Added a readonly textbox in the data form to show "Partial N" when applicable, introduced partialNumber state and logic in selectedProductionOrderChanged (including API call to service.getPartial with error handling), and ensure data.NumberOfPartial is set. Update list column formatter to append "- Partial N" to the order number when present. Also add getPartial() to the service, fix a header text typo ("Adjs 4 aa" → "Adjs 4"), and add a debug log in the view activate method.